### PR TITLE
build: Add CMake-based build system (1 of N)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,12 @@ project("Bitcoin Core"
   LANGUAGES CXX C ASM
 )
 
+set(CLIENT_VERSION_IS_RELEASE "false")
+set(COPYRIGHT_YEAR "2023")
+set(COPYRIGHT_HOLDERS "The %s developers")
+set(COPYRIGHT_HOLDERS_FINAL "The ${PROJECT_NAME} developers")
+set(PACKAGE_BUGREPORT "https://github.com/bitcoin/bitcoin/issues")
+
 # Configurable options.
 # When adding a new option, end the <help_text> with a full stop for consistency.
 include(CMakeDependentOption)
@@ -51,6 +57,8 @@ else()
   list(APPEND configure_warnings "No PIE options will be passed to a linker for executable targets.")
 endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+add_subdirectory(src)
 
 message("\n")
 message("Configure summary")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,99 @@
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# IMPORTANT: Changes which affect binary results may not be quietly gated
+#            by CMake version.
+#
+# Debian 10 Buster, https://wiki.debian.org/LTS, EOL 2024:
+#  - CMake 3.13.4, https://packages.debian.org/buster/cmake
+#
+# Ubuntu 22.04 Jammy, https://wiki.ubuntu.com/Releases, EOL 2032:
+#  - CMake 3.22.1, https://packages.ubuntu.com/jammy/cmake
+#
+# Visual Studio 17 2022, https://visualstudio.microsoft.com:
+#  - CMake 3.24
+#
+# All policies known to the running version of CMake and introduced
+# in the 3.24 version or earlier will be set to use NEW behavior.
+# All policies introduced in later versions will be unset.
+# See: https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html
+cmake_minimum_required(VERSION 3.13...3.24)
+
+project("Bitcoin Core"
+  VERSION 24.99.0
+  DESCRIPTION "Bitcoin client software"
+  HOMEPAGE_URL "https://bitcoincore.org/"
+  LANGUAGES CXX C ASM
+)
+
+# Configurable options.
+# When adding a new option, end the <help_text> with a full stop for consistency.
+include(CMakeDependentOption)
+cmake_dependent_option(CXX20 "Enable compilation in C++20 mode." OFF "NOT MSVC" ON)
+
+if(CXX20)
+  set(CMAKE_CXX_STANDARD 20)
+else()
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(configure_warnings)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.14)
+  include(CheckPIESupported)
+  check_pie_supported(OUTPUT_VARIABLE check_pie_output LANGUAGES CXX)
+  if(NOT CMAKE_CXX_LINK_PIE_SUPPORTED)
+    list(APPEND configure_warnings "PIE link options are not supported for executable targets: ${check_pie_output}.")
+  endif()
+else()
+  list(APPEND configure_warnings "No PIE options will be passed to a linker for executable targets.")
+endif()
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+message("\n")
+message("Configure summary")
+message("=================")
+get_directory_property(definitions COMPILE_DEFINITIONS)
+string(REPLACE ";" " " definitions "${definitions}")
+message("Preprocessor defined macros ........... ${definitions}")
+message("C compiler ............................ ${CMAKE_C_COMPILER}")
+message("CFLAGS ................................ ${CMAKE_C_FLAGS}")
+message("C++ compiler .......................... ${CMAKE_CXX_COMPILER}")
+message("CXXFLAGS .............................. ${CMAKE_CXX_FLAGS}")
+get_directory_property(common_compile_options COMPILE_OPTIONS)
+string(REPLACE ";" " " common_compile_options "${common_compile_options}")
+message("Common compile options ................ ${common_compile_options}")
+get_directory_property(common_link_options LINK_OPTIONS)
+string(REPLACE ";" " " common_link_options "${common_link_options}")
+message("Common link options ................... ${common_link_options}")
+if(DEFINED CMAKE_BUILD_TYPE)
+  message("Build type:")
+  message(" - CMAKE_BUILD_TYPE ................... ${CMAKE_BUILD_TYPE}")
+  string(TOUPPER "${CMAKE_BUILD_TYPE}" build_type)
+  message(" - CFLAGS ............................. ${CMAKE_C_FLAGS_${build_type}}")
+  message(" - CXXFLAGS ........................... ${CMAKE_CXX_FLAGS_${build_type}}")
+  message(" - LDFLAGS for executables ............ ${CMAKE_EXE_LINKER_FLAGS_${build_type}}")
+  message(" - LDFLAGS for shared libraries ....... ${CMAKE_SHARED_LINKER_FLAGS_${build_type}}")
+else()
+  message("Available configurations .............. ${CMAKE_CONFIGURATION_TYPES}")
+  message("Debug configuration:")
+  message(" - CFLAGS ............................. ${CMAKE_C_FLAGS_DEBUG}")
+  message(" - CXXFLAGS ........................... ${CMAKE_CXX_FLAGS_DEBUG}")
+  message(" - LDFLAGS for executables ............ ${CMAKE_EXE_LINKER_FLAGS_DEBUG}")
+  message(" - LDFLAGS for shared libraries ....... ${CMAKE_SHARED_LINKER_FLAGS_DEBUG}")
+  message("Release configuration:")
+  message(" - CFLAGS ............................. ${CMAKE_C_FLAGS_RELEASE}")
+  message(" - CXXFLAGS ........................... ${CMAKE_CXX_FLAGS_RELEASE}")
+  message(" - LDFLAGS for executables ............ ${CMAKE_EXE_LINKER_FLAGS_RELEASE}")
+  message(" - LDFLAGS for shared libraries ....... ${CMAKE_SHARED_LINKER_FLAGS_RELEASE}")
+endif()
+message("\n")
+if(configure_warnings)
+    message("  ******\n")
+    foreach(warning IN LISTS configure_warnings)
+      message(WARNING "${warning}")
+    endforeach()
+    message("  ******\n")
+endif()

--- a/cmake/bitcoin-config.h.in
+++ b/cmake/bitcoin-config.h.in
@@ -1,0 +1,45 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CONFIG_H
+
+#define BITCOIN_CONFIG_H
+
+/* Version Build */
+#define CLIENT_VERSION_BUILD @PROJECT_VERSION_PATCH@
+
+/* Version is release */
+#define CLIENT_VERSION_IS_RELEASE @CLIENT_VERSION_IS_RELEASE@
+
+/* Major version */
+#define CLIENT_VERSION_MAJOR @PROJECT_VERSION_MAJOR@
+
+/* Minor version */
+#define CLIENT_VERSION_MINOR @PROJECT_VERSION_MINOR@
+
+/* Copyright holder(s) before %s replacement */
+#define COPYRIGHT_HOLDERS "@COPYRIGHT_HOLDERS@"
+
+/* Copyright holder(s) */
+#define COPYRIGHT_HOLDERS_FINAL "@COPYRIGHT_HOLDERS_FINAL@"
+
+/* Replacement for %s in copyright holders string */
+#define COPYRIGHT_HOLDERS_SUBSTITUTION "@PROJECT_NAME@"
+
+/* Copyright year */
+#define COPYRIGHT_YEAR @COPYRIGHT_YEAR@
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "@PACKAGE_BUGREPORT@"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "@PROJECT_NAME@"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL "@PROJECT_HOMEPAGE_URL@"
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "@PROJECT_VERSION@"
+
+#endif //BITCOIN_CONFIG_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+configure_file(${CMAKE_SOURCE_DIR}/cmake/bitcoin-config.h.in config/bitcoin-config.h @ONLY)
+add_compile_definitions(HAVE_CONFIG_H)
+include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
This is a first PR into a staging branch as suggested in https://github.com/bitcoin/bitcoin/pull/27060#issuecomment-1431798320.

This PR:
1. Establishes the minimum required CMake [version](https://gitlab.kitware.com/cmake/community/-/wikis/CMake-Versions-on-Linux-Distros). As it looks non-productive to support Ubuntu Bionic as a build platform, version [3.13](https://cmake.org/cmake/help/latest/release/3.13.html) has been chosen.

2. Creates a `bitcoin-config.h` header in the build tree.

## Notes for reviewers

To configure a build system, one can run in their local repo root:
- on Linux / *BSD / macOS:
```sh
cmake -S . -B  build
```
- on Windows:
```cmd
cmake -G "Visual Studio 17 2022" -A x64 -S . -B build
```

To re-configure, it is recommended to use the clean build tree, for example:
```sh
rm -rf build
```

For now, the only artifact we explicitly create in the build tree is a `bitcoin-config.h` header:
```sh
cat build/src/config/bitcoin-config.h
```