### PR TITLE
build: Add CMake-based build system (2 of N) 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,8 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 include(CheckSourceCompilesAndLinks)
 include(cmake/introspection.cmake)
 
+include(cmake/crc32c.cmake)
+
 add_subdirectory(src)
 
 message("\n")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,8 @@ else()
 endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+include(cmake/introspection.cmake)
+
 add_subdirectory(src)
 
 message("\n")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ include(CheckSourceCompilesAndLinks)
 include(cmake/introspection.cmake)
 
 include(cmake/crc32c.cmake)
+include(cmake/leveldb.cmake)
 
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ set(COPYRIGHT_HOLDERS "The %s developers")
 set(COPYRIGHT_HOLDERS_FINAL "The ${PROJECT_NAME} developers")
 set(PACKAGE_BUGREPORT "https://github.com/bitcoin/bitcoin/issues")
 
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/module)
+
 # Configurable options.
 # When adding a new option, end the <help_text> with a full stop for consistency.
 include(CMakeDependentOption)
@@ -58,6 +60,7 @@ else()
 endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+include(CheckSourceCompilesAndLinks)
 include(cmake/introspection.cmake)
 
 add_subdirectory(src)

--- a/cmake/bitcoin-config.h.in
+++ b/cmake/bitcoin-config.h.in
@@ -30,14 +30,137 @@
 /* Copyright year */
 #define COPYRIGHT_YEAR @COPYRIGHT_YEAR@
 
+/* Define this symbol if you have __builtin_clzl */
+#cmakedefine HAVE_BUILTIN_CLZL 1
+
+/* Define this symbol if you have __builtin_clzll */
+#cmakedefine HAVE_BUILTIN_CLZLL 1
+
 /* Define to 1 if you have the <byteswap.h> header file. */
 #cmakedefine HAVE_BYTESWAP_H 1
+
+/* Define to 1 if you have the declaration of `be16toh', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_BE16TOH
+
+/* Define to 1 if you have the declaration of `be32toh', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_BE32TOH
+
+/* Define to 1 if you have the declaration of `be64toh', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_BE64TOH
+
+/* Define to 1 if you have the declaration of `bswap_16', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_BSWAP_16
+
+/* Define to 1 if you have the declaration of `bswap_32', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_BSWAP_32
+
+/* Define to 1 if you have the declaration of `bswap_64', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_BSWAP_64
+
+/* Define to 1 if you have the declaration of `fork', and to 0 if you don't.
+   */
+#cmakedefine01 HAVE_DECL_FORK
+
+/* Define to 1 if you have the declaration of `freeifaddrs', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_FREEIFADDRS
+
+/* Define to 1 if you have the declaration of `getifaddrs', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_GETIFADDRS
+
+/* Define to 1 if you have the declaration of `htobe16', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_HTOBE16
+
+/* Define to 1 if you have the declaration of `htobe32', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_HTOBE32
+
+/* Define to 1 if you have the declaration of `htobe64', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_HTOBE64
+
+/* Define to 1 if you have the declaration of `htole16', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_HTOLE16
+
+/* Define to 1 if you have the declaration of `htole32', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_HTOLE32
+
+/* Define to 1 if you have the declaration of `htole64', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_HTOLE64
+
+/* Define to 1 if you have the declaration of `le16toh', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_LE16TOH
+
+/* Define to 1 if you have the declaration of `le32toh', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_LE32TOH
+
+/* Define to 1 if you have the declaration of `le64toh', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_LE64TOH
+
+/* Define to 1 if you have the declaration of `pipe2', and to 0 if you don't.
+   */
+#cmakedefine01 HAVE_DECL_PIPE2
+
+/* Define to 1 if you have the declaration of `setsid', and to 0 if you don't.
+   */
+#cmakedefine01 HAVE_DECL_SETSID
 
 /* Define to 1 if you have the <endian.h> header file. */
 #cmakedefine HAVE_ENDIAN_H 1
 
+/* Define to 1 if fdatasync is available. */
+#cmakedefine HAVE_FDATASYNC 1
+
+/* Define this symbol if the BSD getentropy system call is available with
+   sys/random.h */
+#cmakedefine HAVE_GETENTROPY_RAND 1
+
+/* Define this symbol if gmtime_r is available */
+#cmakedefine HAVE_GMTIME_R 1
+
+/* Define this symbol if you have malloc_info */
+#cmakedefine HAVE_MALLOC_INFO 1
+
+/* Define this symbol if you have mallopt with M_ARENA_MAX */
+#cmakedefine HAVE_MALLOPT_ARENA_MAX 1
+
+/* Define to 1 if O_CLOEXEC flag is available. */
+#cmakedefine01 HAVE_O_CLOEXEC
+
+/* Define this symbol if you have posix_fallocate */
+#cmakedefine HAVE_POSIX_FALLOCATE 1
+
+/* Define this symbol to build code that uses getauxval) */
+#cmakedefine HAVE_STRONG_GETAUXVAL 1
+
+/* Define this symbol if the BSD sysctl() is available */
+#cmakedefine HAVE_SYSCTL 1
+
+/* Define this symbol if the BSD sysctl(KERN_ARND) is available */
+#cmakedefine HAVE_SYSCTL_ARND 1
+
+/* Define to 1 if std::system or ::wsystem is available. */
+#cmakedefine HAVE_SYSTEM 1
+
 /* Define to 1 if you have the <sys/endian.h> header file. */
 #cmakedefine HAVE_SYS_ENDIAN_H 1
+
+/* Define this symbol if the Linux getrandom system call is available */
+#cmakedefine HAVE_SYS_GETRANDOM 1
 
 /* Define to 1 if you have the <sys/prctl.h> header file. */
 #cmakedefine HAVE_SYS_PRCTL_H 1
@@ -62,6 +185,9 @@
 
 /* Define to the version of this package. */
 #define PACKAGE_VERSION "@PROJECT_VERSION@"
+
+/* Define to 1 if strerror_r returns char *. */
+#cmakedefine STRERROR_R_CHAR_P 1
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */

--- a/cmake/bitcoin-config.h.in
+++ b/cmake/bitcoin-config.h.in
@@ -30,6 +30,27 @@
 /* Copyright year */
 #define COPYRIGHT_YEAR @COPYRIGHT_YEAR@
 
+/* Define to 1 if you have the <byteswap.h> header file. */
+#cmakedefine HAVE_BYTESWAP_H 1
+
+/* Define to 1 if you have the <endian.h> header file. */
+#cmakedefine HAVE_ENDIAN_H 1
+
+/* Define to 1 if you have the <sys/endian.h> header file. */
+#cmakedefine HAVE_SYS_ENDIAN_H 1
+
+/* Define to 1 if you have the <sys/prctl.h> header file. */
+#cmakedefine HAVE_SYS_PRCTL_H 1
+
+/* Define to 1 if you have the <sys/resources.h> header file. */
+#cmakedefine HAVE_SYS_RESOURCES_H 1
+
+/* Define to 1 if you have the <sys/vmmeter.h> header file. */
+#cmakedefine HAVE_SYS_VMMETER_H 1
+
+/* Define to 1 if you have the <vm/vm_param.h> header file. */
+#cmakedefine HAVE_VM_VM_PARAM_H 1
+
 /* Define to the address where bug reports for this package should be sent. */
 #define PACKAGE_BUGREPORT "@PACKAGE_BUGREPORT@"
 

--- a/cmake/bitcoin-config.h.in
+++ b/cmake/bitcoin-config.h.in
@@ -6,6 +6,9 @@
 
 #define BITCOIN_CONFIG_H
 
+/* Define this symbol if type char equals int8_t */
+#cmakedefine CHAR_EQUALS_INT8 1
+
 /* Version Build */
 #define CLIENT_VERSION_BUILD @PROJECT_VERSION_PATCH@
 
@@ -118,6 +121,12 @@
 /* Define to 1 if you have the declaration of `setsid', and to 0 if you don't.
    */
 #cmakedefine01 HAVE_DECL_SETSID
+
+/* Define if the visibility attribute is supported. */
+#cmakedefine HAVE_DEFAULT_VISIBILITY_ATTRIBUTE 1
+
+/* Define if the dllexport attribute is supported. */
+#cmakedefine HAVE_DLLEXPORT_ATTRIBUTE 1
 
 /* Define to 1 if you have the <endian.h> header file. */
 #cmakedefine HAVE_ENDIAN_H 1

--- a/cmake/bitcoin-config.h.in
+++ b/cmake/bitcoin-config.h.in
@@ -42,4 +42,8 @@
 /* Define to the version of this package. */
 #define PACKAGE_VERSION "@PROJECT_VERSION@"
 
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#cmakedefine WORDS_BIGENDIAN 1
+
 #endif //BITCOIN_CONFIG_H

--- a/cmake/crc32c.cmake
+++ b/cmake/crc32c.cmake
@@ -1,0 +1,113 @@
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# This file is part of the transition from Autotools to CMake. Once CMake
+# support has been merged we should switch to using the upstream CMake
+# buildsystem.
+
+include(CheckCXXSourceCompiles)
+
+# Check for __builtin_prefetch support in the compiler.
+check_cxx_source_compiles("
+  int main() {
+    char data = 0;
+    const char* address = &data;
+    __builtin_prefetch(address, 0, 0);
+    return 0;
+  }
+  " HAVE_BUILTIN_PREFETCH
+)
+
+# Check for _mm_prefetch support in the compiler.
+check_cxx_source_compiles("
+  #if defined(_MSC_VER)
+  #include <intrin.h>
+  #else
+  #include <xmmintrin.h>
+  #endif
+
+  int main() {
+    char data = 0;
+    const char* address = &data;
+    _mm_prefetch(address, _MM_HINT_NTA);
+    return 0;
+  }
+  " HAVE_MM_PREFETCH
+)
+
+# Check for SSE4.2 support in the compiler.
+if(MSVC)
+  set(SSE42_CXXFLAGS /arch:AVX)
+else()
+  set(SSE42_CXXFLAGS -msse4.2)
+endif()
+check_cxx_source_compiles_with_flags("${SSE42_CXXFLAGS}" "
+  #include <cstdint>
+  #if defined(_MSC_VER)
+  #include <intrin.h>
+  #elif defined(__GNUC__) && defined(__SSE4_2__)
+  #include <nmmintrin.h>
+  #endif
+
+  int main() {
+    uint64_t l = 0;
+    l = _mm_crc32_u8(l, 0);
+    l = _mm_crc32_u32(l, 0);
+    l = _mm_crc32_u64(l, 0);
+    return l;
+  }
+  " HAVE_SSE42
+)
+
+# Check for ARMv8 w/ CRC and CRYPTO extensions support in the compiler.
+set(ARM_CRC_CXXFLAGS -march=armv8-a+crc)
+check_cxx_source_compiles_with_flags("${ARM_CRC_CXXFLAGS}" "
+  #include <arm_acle.h>
+  #include <arm_neon.h>
+
+  int main() {
+  #ifdef __aarch64__
+    __crc32cb(0, 0); __crc32ch(0, 0); __crc32cw(0, 0); __crc32cd(0, 0);
+    vmull_p64(0, 0);
+  #else
+  #error crc32c library does not support hardware acceleration on 32-bit ARM
+  #endif
+    return 0;
+  }
+  " HAVE_ARM64_CRC32C
+)
+
+add_library(crc32c STATIC EXCLUDE_FROM_ALL
+  ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c.cc
+  ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c_portable.cc
+)
+
+target_compile_definitions(crc32c
+  PRIVATE
+    HAVE_BUILTIN_PREFETCH=$<BOOL:${HAVE_BUILTIN_PREFETCH}>
+    HAVE_MM_PREFETCH=$<BOOL:${HAVE_MM_PREFETCH}>
+    HAVE_STRONG_GETAUXVAL=$<BOOL:${HAVE_STRONG_GETAUXVAL}>
+    HAVE_SSE42=$<BOOL:${HAVE_SSE42}>
+    HAVE_ARM64_CRC32C=$<BOOL:${HAVE_ARM64_CRC32C}>
+    BYTE_ORDER_BIG_ENDIAN=${WORDS_BIGENDIAN}
+)
+
+target_include_directories(crc32c
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/crc32c/include>
+)
+
+if(HAVE_SSE42)
+  target_sources(crc32c PRIVATE ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c_sse42.cc)
+  set_property(SOURCE ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c_sse42.cc
+    APPEND PROPERTY COMPILE_OPTIONS ${SSE42_CXXFLAGS}
+  )
+endif()
+
+if(HAVE_ARM64_CRC32C)
+  target_sources(crc32c PRIVATE ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c_arm64.cc)
+  set_property(SOURCE ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c_arm64.cc
+    APPEND PROPERTY COMPILE_OPTIONS ${ARM_CRC_CXXFLAGS}
+  )
+endif()

--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -240,3 +240,26 @@ check_cxx_source_compiles("
   }
   " HAVE_SYSCTL_ARND
 )
+
+check_cxx_source_compiles("
+  #include <cstdint>
+  #include <type_traits>
+
+  int main()
+  {
+    static_assert(std::is_same<int8_t, char>::value);
+  }
+  " CHAR_EQUALS_INT8
+)
+
+check_cxx_source_compiles("
+  int foo(void) __attribute__((visibility(\"default\")));
+  int main(){}
+  " HAVE_DEFAULT_VISIBILITY_ATTRIBUTE
+)
+
+check_cxx_source_compiles("
+  __declspec(dllexport) int foo(void);
+  int main(){}
+  " HAVE_DLLEXPORT_ATTRIBUTE
+)

--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+include(TestBigEndian)
+
+test_big_endian(WORDS_BIGENDIAN)

--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -2,6 +2,16 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+include(CheckIncludeFileCXX)
 include(TestBigEndian)
 
 test_big_endian(WORDS_BIGENDIAN)
+
+# The following HAVE_{HEADER}_H variables go to the bitcoin-config.h header.
+check_include_file_cxx(byteswap.h HAVE_BYTESWAP_H)
+check_include_file_cxx(endian.h HAVE_ENDIAN_H)
+check_include_file_cxx(sys/endian.h HAVE_SYS_ENDIAN_H)
+check_include_file_cxx(sys/prctl.h HAVE_SYS_PRCTL_H)
+check_include_file_cxx(sys/resources.h HAVE_SYS_RESOURCES_H)
+check_include_file_cxx(sys/vmmeter.h HAVE_SYS_VMMETER_H)
+check_include_file_cxx(vm/vm_param.h HAVE_VM_VM_PARAM_H)

--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -2,6 +2,8 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+include(CheckCXXSourceCompiles)
+include(CheckCXXSymbolExists)
 include(CheckIncludeFileCXX)
 include(TestBigEndian)
 
@@ -15,3 +17,226 @@ check_include_file_cxx(sys/prctl.h HAVE_SYS_PRCTL_H)
 check_include_file_cxx(sys/resources.h HAVE_SYS_RESOURCES_H)
 check_include_file_cxx(sys/vmmeter.h HAVE_SYS_VMMETER_H)
 check_include_file_cxx(vm/vm_param.h HAVE_VM_VM_PARAM_H)
+
+check_cxx_source_compiles("
+  int main()
+  {
+    (void) __builtin_clzl(0);
+  }
+  " HAVE_BUILTIN_CLZL
+)
+
+check_cxx_source_compiles("
+  int main()
+  {
+    (void) __builtin_clzll(0);
+  }
+  " HAVE_BUILTIN_CLZLL
+)
+
+check_cxx_symbol_exists(O_CLOEXEC "fcntl.h" HAVE_O_CLOEXEC)
+
+if(HAVE_BYTESWAP_H)
+  check_cxx_symbol_exists(bswap_16 "byteswap.h" HAVE_DECL_BSWAP_16)
+  check_cxx_symbol_exists(bswap_32 "byteswap.h" HAVE_DECL_BSWAP_32)
+  check_cxx_symbol_exists(bswap_64 "byteswap.h" HAVE_DECL_BSWAP_64)
+endif()
+
+if(HAVE_ENDIAN_H OR HAVE_SYS_ENDIAN_H)
+  if(HAVE_ENDIAN_H)
+    set(ENDIAN_HEADER "endian.h")
+  else()
+    set(ENDIAN_HEADER "sys/endian.h")
+  endif()
+  check_cxx_symbol_exists(be16toh ${ENDIAN_HEADER} HAVE_DECL_BE16TOH)
+  check_cxx_symbol_exists(be32toh ${ENDIAN_HEADER} HAVE_DECL_BE32TOH)
+  check_cxx_symbol_exists(be64toh ${ENDIAN_HEADER} HAVE_DECL_BE64TOH)
+  check_cxx_symbol_exists(htobe16 ${ENDIAN_HEADER} HAVE_DECL_HTOBE16)
+  check_cxx_symbol_exists(htobe32 ${ENDIAN_HEADER} HAVE_DECL_HTOBE32)
+  check_cxx_symbol_exists(htobe64 ${ENDIAN_HEADER} HAVE_DECL_HTOBE64)
+  check_cxx_symbol_exists(htole16 ${ENDIAN_HEADER} HAVE_DECL_HTOLE16)
+  check_cxx_symbol_exists(htole32 ${ENDIAN_HEADER} HAVE_DECL_HTOLE32)
+  check_cxx_symbol_exists(htole64 ${ENDIAN_HEADER} HAVE_DECL_HTOLE64)
+  check_cxx_symbol_exists(le16toh ${ENDIAN_HEADER} HAVE_DECL_LE16TOH)
+  check_cxx_symbol_exists(le32toh ${ENDIAN_HEADER} HAVE_DECL_LE32TOH)
+  check_cxx_symbol_exists(le64toh ${ENDIAN_HEADER} HAVE_DECL_LE64TOH)
+endif()
+
+check_include_file_cxx(unistd.h HAVE_UNISTD_H)
+if(HAVE_UNISTD_H)
+  check_cxx_symbol_exists(fdatasync "unistd.h" HAVE_FDATASYNC)
+  check_cxx_symbol_exists(fork "unistd.h" HAVE_DECL_FORK)
+  check_cxx_symbol_exists(pipe2 "unistd.h" HAVE_DECL_PIPE2)
+  check_cxx_symbol_exists(setsid "unistd.h" HAVE_DECL_SETSID)
+endif()
+
+check_include_file_cxx(sys/types.h HAVE_SYS_TYPES_H)
+check_include_file_cxx(ifaddrs.h HAVE_IFADDRS_H)
+if(HAVE_SYS_TYPES_H AND HAVE_IFADDRS_H)
+  check_cxx_symbol_exists(freeifaddrs "sys/types.h;ifaddrs.h" HAVE_DECL_FREEIFADDRS)
+  check_cxx_symbol_exists(getifaddrs "sys/types.h;ifaddrs.h" HAVE_DECL_GETIFADDRS)
+  # Illumos/SmartOS requires linking with -lsocket if
+  # using getifaddrs & freeifaddrs.
+  # See: https://github.com/bitcoin/bitcoin/pull/21486
+  if(HAVE_DECL_GETIFADDRS AND HAVE_DECL_FREEIFADDRS)
+    set(check_socket_source "
+      #include <sys/types.h>
+      #include <ifaddrs.h>
+
+      int main() {
+        struct ifaddrs* ifaddr;
+        getifaddrs(&ifaddr);
+        freeifaddrs(ifaddr);
+      }
+    ")
+    check_cxx_source_links("${check_socket_source}" IFADDR_LINKS_WITHOUT_LIBSOCKET)
+    if(NOT IFADDR_LINKS_WITHOUT_LIBSOCKET)
+      check_cxx_source_links_with_libs(socket "${check_socket_source}" IFADDR_NEEDS_LINK_TO_LIBSOCKET)
+      if(IFADDR_NEEDS_LINK_TO_LIBSOCKET)
+        link_libraries(socket)
+      else()
+        message(FATAL_ERROR "Cannot figure out how to use getifaddrs/freeifaddrs.")
+      endif()
+    endif()
+  endif()
+endif()
+
+# Check for gmtime_r(), fallback to gmtime_s() if that is unavailable.
+# Fail if neither are available.
+check_cxx_source_compiles("
+  #include <ctime>
+
+  int main()
+  {
+    gmtime_r((const time_t*)nullptr, (struct tm*)nullptr);
+  }
+  " HAVE_GMTIME_R
+)
+if(NOT HAVE_GMTIME_R)
+  check_cxx_source_compiles("
+    #include <ctime>
+
+    int main()
+    {
+      gmtime_s((struct tm*)nullptr, (const time_t*)nullptr);
+    }
+    " HAVE_GMTIME_S
+  )
+  if(NOT HAVE_GMTIME_S)
+    message(FATAL_ERROR "Both gmtime_r and gmtime_s are unavailable.")
+  endif()
+endif()
+
+check_cxx_symbol_exists(std::system "cstdlib" HAVE_STD_SYSTEM)
+check_cxx_symbol_exists(::_wsystem "stdlib.h" HAVE__WSYSTEM)
+if(HAVE_STD_SYSTEM OR HAVE__WSYSTEM)
+  set(HAVE_SYSTEM 1)
+endif()
+
+check_include_file_cxx(string.h HAVE_STRING_H)
+if(HAVE_STRING_H)
+  check_cxx_source_compiles("
+    #include <string.h>
+
+    int main()
+    {
+      char buf[100];
+      char* p{strerror_r(0, buf, sizeof buf)};
+      (void)p;
+    }
+    " STRERROR_R_CHAR_P
+  )
+endif()
+
+# Check for malloc_info (for memory statistics information in getmemoryinfo).
+check_cxx_symbol_exists(malloc_info "malloc.h" HAVE_MALLOC_INFO)
+
+# Check for mallopt(M_ARENA_MAX) (to set glibc arenas).
+check_cxx_source_compiles("
+  #include <malloc.h>
+
+  int main()
+  {
+    mallopt(M_ARENA_MAX, 1);
+  }
+  " HAVE_MALLOPT_ARENA_MAX
+)
+
+# Check for posix_fallocate().
+check_cxx_source_compiles("
+  // same as in src/util/system.cpp
+  #ifdef __linux__
+  #ifdef _POSIX_C_SOURCE
+  #undef _POSIX_C_SOURCE
+  #endif
+  #define _POSIX_C_SOURCE 200112L
+  #endif // __linux__
+  #include <fcntl.h>
+
+  int main()
+  {
+    return posix_fallocate(0, 0, 0);
+  }
+  " HAVE_POSIX_FALLOCATE
+)
+
+# Check for strong getauxval() support in the system headers.
+check_cxx_source_compiles("
+  #include <sys/auxv.h>
+
+  int main()
+  {
+    getauxval(AT_HWCAP);
+  }
+  " HAVE_STRONG_GETAUXVAL
+)
+
+# Check for different ways of gathering OS randomness:
+# - Linux getrandom()
+check_cxx_source_compiles("
+  #include <unistd.h>
+  #include <sys/syscall.h>
+  #include <linux/random.h>
+
+  int main()
+  {
+    syscall(SYS_getrandom, nullptr, 32, 0);
+  }
+  " HAVE_SYS_GETRANDOM
+)
+
+# - BSD getentropy()
+check_cxx_symbol_exists(getentropy "unistd.h;sys/random.h" HAVE_GETENTROPY_RAND)
+
+# - BSD sysctl()
+check_cxx_source_compiles("
+  #include <sys/types.h>
+  #include <sys/sysctl.h>
+
+  #ifdef __linux__
+  #error Don't use sysctl on Linux, it's deprecated even when it works
+  #endif
+
+  int main()
+  {
+    sysctl(nullptr, 2, nullptr, nullptr, nullptr, 0);
+  }
+  " HAVE_SYSCTL
+)
+
+# - BSD sysctl(KERN_ARND)
+check_cxx_source_compiles("
+  #include <sys/types.h>
+  #include <sys/sysctl.h>
+
+  #ifdef __linux__
+  #error Don't use sysctl on Linux, it's deprecated even when it works
+  #endif
+
+  int main()
+  {
+    static int name[2] = {CTL_KERN, KERN_ARND};
+    sysctl(name, 2, nullptr, nullptr, nullptr, 0);
+  }
+  " HAVE_SYSCTL_ARND
+)

--- a/cmake/leveldb.cmake
+++ b/cmake/leveldb.cmake
@@ -1,0 +1,94 @@
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# This file is part of the transition from Autotools to CMake. Once CMake
+# support has been merged we should switch to using the upstream CMake
+# buildsystem.
+
+include(CheckCXXSymbolExists)
+check_cxx_symbol_exists(F_FULLFSYNC "fcntl.h" HAVE_FULLFSYNC)
+
+add_library(leveldb STATIC EXCLUDE_FROM_ALL
+  ${PROJECT_SOURCE_DIR}/src/leveldb/db/builder.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/db/c.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/db/db_impl.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/db/db_iter.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/db/dbformat.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/db/dumpfile.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/db/filename.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/db/log_reader.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/db/log_writer.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/db/memtable.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/db/repair.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/db/table_cache.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/db/version_edit.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/db/version_set.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/db/write_batch.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/table/block.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/table/block_builder.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/table/filter_block.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/table/format.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/table/iterator.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/table/merger.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/table/table.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/table/table_builder.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/table/two_level_iterator.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/util/arena.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/util/bloom.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/util/cache.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/util/coding.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/util/comparator.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/util/crc32c.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/util/env.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/util/filter_policy.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/util/hash.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/util/histogram.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/util/logging.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/util/options.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/util/status.cc
+  ${PROJECT_SOURCE_DIR}/src/leveldb/helpers/memenv/memenv.cc
+)
+if(WIN32)
+  target_sources(leveldb PRIVATE ${PROJECT_SOURCE_DIR}/src/leveldb/util/env_windows.cc)
+  set_property(SOURCE ${PROJECT_SOURCE_DIR}/src/leveldb/util/env_windows.cc
+    APPEND PROPERTY COMPILE_OPTIONS $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:Release>>:/wd4722>
+  )
+else()
+  target_sources(leveldb PRIVATE ${PROJECT_SOURCE_DIR}/src/leveldb/util/env_posix.cc)
+endif()
+
+target_compile_definitions(leveldb
+  PRIVATE
+    HAVE_SNAPPY=0
+    HAVE_CRC32C=1
+    HAVE_FDATASYNC=$<BOOL:${HAVE_FDATASYNC}>
+    HAVE_FULLFSYNC=$<BOOL:${HAVE_FULLFSYNC}>
+    HAVE_O_CLOEXEC=$<BOOL:${HAVE_O_CLOEXEC}>
+    FALLTHROUGH_INTENDED=[[fallthrough]]
+    LEVELDB_IS_BIG_ENDIAN=${WORDS_BIGENDIAN}
+)
+
+if(WIN32)
+  target_compile_definitions(leveldb
+    PRIVATE
+      LEVELDB_PLATFORM_WINDOWS
+      _UNICODE
+      UNICODE
+      __USE_MINGW_ANSI_STDIO=1
+  )
+else()
+  target_compile_definitions(leveldb PRIVATE LEVELDB_PLATFORM_POSIX)
+endif()
+
+target_include_directories(leveldb
+  PRIVATE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/leveldb>
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/leveldb/include>
+)
+
+#TODO: figure out how to filter out:
+# -Wconditional-uninitialized -Werror=conditional-uninitialized -Wsuggest-override -Werror=suggest-override
+
+target_link_libraries(leveldb PRIVATE crc32c)

--- a/cmake/module/CheckSourceCompilesAndLinks.cmake
+++ b/cmake/module/CheckSourceCompilesAndLinks.cmake
@@ -1,0 +1,36 @@
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+include(CheckCXXSourceCompiles)
+include(CMakePushCheckState)
+
+# This avoids running the linker.
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+macro(check_cxx_source_links source)
+  set(CMAKE_TRY_COMPILE_TARGET_TYPE EXECUTABLE)
+  check_cxx_source_compiles("${source}" ${ARGN})
+  set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+endmacro()
+
+macro(check_cxx_source_compiles_with_flags flags source)
+  cmake_push_check_state(RESET)
+  string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${flags}")
+  check_cxx_source_compiles("${source}" ${ARGN})
+  cmake_pop_check_state()
+endmacro()
+
+macro(check_cxx_source_links_with_flags flags source)
+  cmake_push_check_state(RESET)
+  string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${flags}")
+  check_cxx_source_links("${source}" ${ARGN})
+  cmake_pop_check_state()
+endmacro()
+
+macro(check_cxx_source_links_with_libs libs source)
+  cmake_push_check_state(RESET)
+  set(CMAKE_REQUIRED_LIBRARIES "${libs}")
+  check_cxx_source_links("${source}" ${ARGN})
+  cmake_pop_check_state()
+endmacro()


### PR DESCRIPTION
The parent PR: https://github.com/bitcoin/bitcoin/pull/25797.
The previous PR in the staging branch: https://github.com/hebasto/bitcoin/pull/5.

This PR details:

1. Added project-wide system introspection.

| Autoconf macro | Symbols in `bitcoin-config.h` | CMake implementation |
|---|---|---|
| [`AC_INIT`](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/autoconf.html#Initializing-configure) | `PACKAGE_NAME` `PACKAGE_TARNAME` `PACKAGE_VERSION` `PACKAGE_STRING` `PACKAGE_BUGREPORT` `PACKAGE_URL` | Done in https://github.com/hebasto/bitcoin/pull/5, except for `PACKAGE_TARNAME` and `PACKAGE_STRING`, which are not currently used |
| [`AX_CXX_COMPILE_STDCXX`](https://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx.html) | `HAVE_CXX17` `HAVE_CXX20` | CMake uses its own [implementation](https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html) |
| [`AC_C_BIGENDIAN`](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/autoconf.html#index-AC_005fC_005fBIGENDIAN-892) | `AC_APPLE_UNIVERSAL_BUILD` `WORDS_BIGENDIAN` and C headers | CMake uses its own [implementation](https://cmake.org/cmake/help/latest/module/TestBigEndian.html) |
| [`AX_PTHREAD`](https://www.gnu.org/software/autoconf-archive/ax_pthread.html) | `HAVE_PTHREAD` `HAVE_PTHREAD_PRIO_INHERIT` `PTHREAD_CREATE_JOINABLE` | CMake uses its own [implementation](https://cmake.org/cmake/help/latest/module/FindThreads.html) |
| [`AC_SYS_LARGEFILE`](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/autoconf.html#index-AC_005fSYS_005fLARGEFILE-1103) | `_FILE_OFFSET_BITS` `_LARGE_FILES` | _Not implemented yet_ |
| [`AC_FUNC_STRERROR_R`](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/autoconf.html#index-AC_005fFUNC_005fSTRERROR_005fR-517) | `HAVE_DECL_STRERROR_R` `HAVE_STRERROR_R` `STRERROR_R_CHAR_P` and C headers  | Implemented `STRERROR_R_CHAR_P`, others are not used
| C headers |  `HAVE_INTTYPES_H` `HAVE_STDINT_H` `HAVE_STDIO_H` `HAVE_STDLIB_H` `HAVE_STRINGS_H` `HAVE_STRING_H` `HAVE_SYS_STAT_H` `HAVE_SYS_TYPES_H` `HAVE_UNISTD_H` `STDC_HEADERS` | Only `HAVE_STRING_H`, `HAVE_SYS_TYPES_H` and `HAVE_UNISTD_H` are evaluated for internal needs

---

2. Added the `leveldb` build target (including its `crc32c` dependency):

- on Linux / *BSD / macOS:
```sh
cmake -S . -B build
cmake --build build --target leveldb
```

- on Windows:
```cmd
cmake -G "Visual Studio 17 2022" -A x64 -S . -B build
cmake --build build --config Debug --target leveldb  # or --config Release
```

**NOTE**. On Windows (MSVC), the `leveldb` library now uses `crc32c` one. That is not the case when using the current build system from the `build_msvc` directory: https://github.com/hebasto/bitcoin/blob/fe1b3256888bd0e70d0c9655f565e139ec87b606/build_msvc/libleveldb/libleveldb.vcxproj#L53
