### PR TITLE
build: Add CMake-based build system (3 of N)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ include(cmake/introspection.cmake)
 include(cmake/crc32c.cmake)
 include(cmake/leveldb.cmake)
 include(cmake/minisketch.cmake)
+include(cmake/secp256k1.cmake)
 
 include(CheckStdFilesystem)
 check_std_filesystem()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,9 @@ include(cmake/introspection.cmake)
 include(cmake/crc32c.cmake)
 include(cmake/leveldb.cmake)
 
+include(CheckStdFilesystem)
+check_std_filesystem()
+
 add_subdirectory(src)
 
 message("\n")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/module)
 # Configurable options.
 # When adding a new option, end the <help_text> with a full stop for consistency.
 include(CMakeDependentOption)
+option(BUILD_DAEMON "Build bitcoind executable." ON)
 option(ASM "Use assembly routines." ON)
 cmake_dependent_option(CXX20 "Enable compilation in C++20 mode." OFF "NOT MSVC" ON)
 option(THREADLOCAL "Enable features that depend on the C++ thread_local keyword (currently just thread names in debug logs)." ON)
@@ -100,7 +101,14 @@ endif()
 include(AddThreadsIfNeeded)
 add_threads_if_needed()
 
+include(AddBoostIfNeeded)
+add_boost_if_needed()
+
 include(CheckSourceCompilesAndLinks)
+
+include(AddLibeventIfNeeded)
+add_libevent_if_needed()
+
 include(cmake/introspection.cmake)
 
 include(cmake/crc32c.cmake)
@@ -116,6 +124,9 @@ add_subdirectory(src)
 message("\n")
 message("Configure summary")
 message("=================")
+message("Executables:")
+message("  bitcoind ............................ ${BUILD_DAEMON}")
+message("")
 get_directory_property(definitions COMPILE_DEFINITIONS)
 string(REPLACE ";" " " definitions "${definitions}")
 message("Preprocessor defined macros ........... ${definitions}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/module)
 # Configurable options.
 # When adding a new option, end the <help_text> with a full stop for consistency.
 include(CMakeDependentOption)
+option(ASM "Use assembly routines." ON)
 cmake_dependent_option(CXX20 "Enable compilation in C++20 mode." OFF "NOT MSVC" ON)
 
 if(CXX20)
@@ -145,6 +146,7 @@ else()
   message(" - LDFLAGS for executables ............ ${CMAKE_EXE_LINKER_FLAGS_RELEASE}")
   message(" - LDFLAGS for shared libraries ....... ${CMAKE_SHARED_LINKER_FLAGS_RELEASE}")
 endif()
+message("Use assembly routines ................. ${ASM}")
 message("\n")
 if(configure_warnings)
     message("  ******\n")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/module)
 include(CMakeDependentOption)
 option(ASM "Use assembly routines." ON)
 cmake_dependent_option(CXX20 "Enable compilation in C++20 mode." OFF "NOT MSVC" ON)
+option(THREADLOCAL "Enable features that depend on the C++ thread_local keyword (currently just thread names in debug logs)." ON)
 
 if(CXX20)
   set(CMAKE_CXX_STANDARD 20)
@@ -95,6 +96,9 @@ endif()
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   add_compile_definitions(MAC_OSX)
 endif()
+
+include(AddThreadsIfNeeded)
+add_threads_if_needed()
 
 include(CheckSourceCompilesAndLinks)
 include(cmake/introspection.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ include(cmake/introspection.cmake)
 
 include(cmake/crc32c.cmake)
 include(cmake/leveldb.cmake)
+include(cmake/minisketch.cmake)
 
 include(CheckStdFilesystem)
 check_std_filesystem()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,41 @@ else()
 endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+if(WIN32)
+  #[=[
+  This build system supports two ways to build binaries for Windows.
+
+  1. Building on Windows using MSVC.
+  Implementation notes:
+  - /DWIN32 and /D_WINDOWS definitions are included into the CMAKE_CXX_FLAGS_INIT
+    and CMAKE_CXX_FLAGS_INIT variables by default.
+  - A run-time library is selected using the CMAKE_MSVC_RUNTIME_LIBRARY variable.
+  - MSVC-specific options, for example, /Zc:__cplusplus, are additionally required.
+
+  2. Cross-compiling using MinGW.
+  Implementation notes:
+  - WIN32 and _WINDOWS definitions must be provided explicitly.
+  - A run-time library must be specified explicitly using _MT definition.
+  ]=]
+
+  add_compile_definitions(_WIN32_WINNT=0x0601 _WIN32_IE=0x0501 WIN32_LEAN_AND_MEAN NOMINMAX)
+
+  if(MSVC)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    add_compile_options(/utf-8 /Zc:__cplusplus)
+  endif()
+
+  if(MINGW)
+    add_compile_definitions(WIN32 _WINDOWS _MT)
+    # We require Windows 7 (NT 6.1) or later.
+    add_link_options(-Wl,--major-subsystem-version,6 -Wl,--minor-subsystem-version,1)
+  endif()
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  add_compile_definitions(MAC_OSX)
+endif()
+
 include(CheckSourceCompilesAndLinks)
 include(cmake/introspection.cmake)
 

--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -263,3 +263,7 @@ check_cxx_source_compiles("
   int main(){}
   " HAVE_DLLEXPORT_ATTRIBUTE
 )
+
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
+  find_program(BREW_COMMAND brew)
+endif()

--- a/cmake/minisketch.cmake
+++ b/cmake/minisketch.cmake
@@ -1,0 +1,71 @@
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Check for clmul instructions support.
+if(MSVC)
+  set(CLMUL_CXXFLAGS)
+else()
+  set(CLMUL_CXXFLAGS -mpclmul)
+endif()
+check_cxx_source_compiles_with_flags("${CLMUL_CXXFLAGS}" "
+  #include <immintrin.h>
+  #include <cstdint>
+
+  int main()
+  {
+    __m128i a = _mm_cvtsi64_si128((uint64_t)7);
+    __m128i b = _mm_clmulepi64_si128(a, a, 37);
+    __m128i c = _mm_srli_epi64(b, 41);
+    __m128i d = _mm_xor_si128(b, c);
+    uint64_t e = _mm_cvtsi128_si64(d);
+    return e == 0;
+  }
+  " HAVE_CLMUL
+)
+
+add_library(minisketch_defs INTERFACE)
+target_compile_definitions(minisketch_defs INTERFACE
+  DISABLE_DEFAULT_FIELDS
+  ENABLE_FIELD_32
+  $<$<AND:$<BOOL:${HAVE_BUILTIN_CLZL}>,$<BOOL:${HAVE_BUILTIN_CLZLL}>>:HAVE_CLZ>
+)
+
+if(HAVE_CLMUL)
+  add_library(minisketch_clmul OBJECT EXCLUDE_FROM_ALL
+    ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_1byte.cpp
+    ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_2bytes.cpp
+    ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_3bytes.cpp
+    ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_4bytes.cpp
+    ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_5bytes.cpp
+    ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_6bytes.cpp
+    ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_7bytes.cpp
+    ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_8bytes.cpp
+  )
+  target_compile_definitions(minisketch_clmul PUBLIC HAVE_CLMUL)
+  target_compile_options(minisketch_clmul PRIVATE ${CLMUL_CXXFLAGS})
+  target_link_libraries(minisketch_clmul PRIVATE minisketch_defs)
+endif()
+
+add_library(minisketch STATIC EXCLUDE_FROM_ALL
+  ${PROJECT_SOURCE_DIR}/src/minisketch/src/minisketch.cpp
+  ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/generic_1byte.cpp
+  ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/generic_2bytes.cpp
+  ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/generic_3bytes.cpp
+  ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/generic_4bytes.cpp
+  ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/generic_5bytes.cpp
+  ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/generic_6bytes.cpp
+  ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/generic_7bytes.cpp
+  ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/generic_8bytes.cpp
+)
+
+target_include_directories(minisketch
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/minisketch/include>
+)
+
+target_link_libraries(minisketch
+  PRIVATE
+    minisketch_defs
+    $<TARGET_NAME_IF_EXISTS:minisketch_clmul>
+)

--- a/cmake/module/AddBoostIfNeeded.cmake
+++ b/cmake/module/AddBoostIfNeeded.cmake
@@ -1,0 +1,40 @@
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+function(add_boost_if_needed)
+  #[=[
+  TODO: Not all targets, which will be added in the future, require
+        Boost. Therefore, a proper check will be appropriate here.
+
+  Implementation notes:
+  Although only Boost headers are used to build Bitcoin Core,
+  we still leverage a standard CMake's approach to handle
+  dependencies, i.e., the Boost::headers "library".
+  A command target_link_libraries(target PRIVATE Boost::headers)
+  will propagate Boost::headers usage requirements to the target.
+  For Boost::headers such usage requirements is an include
+  directory and other added INTERFACE properties.
+  ]=]
+
+  if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin" AND BREW_COMMAND)
+    execute_process(
+      COMMAND ${BREW_COMMAND} --prefix boost
+      OUTPUT_VARIABLE BOOST_ROOT
+      ERROR_QUIET
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  endif()
+
+  set(Boost_NO_BOOST_CMAKE ON)
+  find_package(Boost 1.64.0 REQUIRED)
+  set_target_properties(Boost::boost PROPERTIES IMPORTED_GLOBAL TRUE)
+  target_compile_definitions(Boost::boost INTERFACE
+    $<$<CONFIG:Debug>:BOOST_MULTI_INDEX_ENABLE_SAFE_MODE>
+  )
+  if(CMAKE_VERSION VERSION_LESS 3.15)
+    add_library(Boost::headers ALIAS Boost::boost)
+  endif()
+
+  mark_as_advanced(Boost_INCLUDE_DIR)
+endfunction()

--- a/cmake/module/AddLibeventIfNeeded.cmake
+++ b/cmake/module/AddLibeventIfNeeded.cmake
@@ -1,0 +1,51 @@
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+macro(check_evhttp_connection_get_peer target)
+  # Check whether evhttp_connection_get_peer expects const char**.
+  # Fail if neither are available.
+  check_cxx_source_compiles("
+    #include <cstdint>
+    #include <event2/http.h>
+
+    int main()
+    {
+        evhttp_connection* conn = (evhttp_connection*)1;
+        const char* host;
+        uint16_t port;
+        evhttp_connection_get_peer(conn, &host, &port);
+    }
+    " HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR
+  )
+  target_compile_definitions(${target} INTERFACE
+    $<$<BOOL:${HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR}>:HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR=1>
+  )
+endmacro()
+
+function(add_libevent_if_needed)
+  # TODO: Not all targets, which will be added in the future,
+  #       require libevent. Therefore, a proper check will be
+  #       appropriate here.
+
+  set(libevent_minimum_version 2.1.8)
+
+  if(MSVC)
+    find_package(Libevent ${libevent_minimum_version} REQUIRED COMPONENTS extra CONFIG)
+    check_evhttp_connection_get_peer(libevent::extra)
+    add_library(libevent::libevent ALIAS libevent::extra)
+    return()
+  endif()
+
+  find_package(PkgConfig)
+  pkg_check_modules(libevent REQUIRED libevent>=${libevent_minimum_version} IMPORTED_TARGET GLOBAL)
+  check_evhttp_connection_get_peer(PkgConfig::libevent)
+  target_link_libraries(PkgConfig::libevent INTERFACE
+    $<$<BOOL:${MINGW}>:iphlpapi;ws2_32>
+  )
+  add_library(libevent::libevent ALIAS PkgConfig::libevent)
+
+  if(NOT WIN32)
+    pkg_check_modules(libevent_pthreads REQUIRED libevent_pthreads>=${libevent_minimum_version} IMPORTED_TARGET)
+  endif()
+endfunction()

--- a/cmake/module/AddThreadsIfNeeded.cmake
+++ b/cmake/module/AddThreadsIfNeeded.cmake
@@ -1,0 +1,33 @@
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+function(add_threads_if_needed)
+  # TODO: Not all targets, which will be added in the future,
+  #       require Threads. Therefore, a proper check will be
+  #       appropriate here.
+
+  set(THREADS_PREFER_PTHREAD_FLAG ON)
+  find_package(Threads REQUIRED)
+
+  set(thread_local)
+  if(MINGW)
+    #[=[
+    mingw32's implementation of thread_local has been shown to behave
+    erroneously under concurrent usage.
+    See:
+     - https://github.com/bitcoin/bitcoin/pull/15849
+     - https://gist.github.com/jamesob/fe9a872051a88b2025b1aa37bfa98605
+    ]=]
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    #[=[
+    FreeBSD's implementation of thread_local is buggy.
+    See:
+     - https://github.com/bitcoin/bitcoin/pull/16059
+     - https://groups.google.com/d/msg/bsdmailinglist/22ncTZAbDp4/Dii_pII5AwAJ
+    ]=]
+  elseif(THREADLOCAL)
+    set(thread_local "$<$<COMPILE_FEATURES:cxx_thread_local>:HAVE_THREAD_LOCAL>")
+  endif()
+  set(THREAD_LOCAL_IF_AVAILABLE "${thread_local}" PARENT_SCOPE)
+endfunction()

--- a/cmake/module/CheckStdFilesystem.cmake
+++ b/cmake/module/CheckStdFilesystem.cmake
@@ -1,0 +1,36 @@
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# GCC 8.x (libstdc++) requires -lstdc++fs
+# Clang 8.x (libc++) requires -lc++fs
+
+function(check_std_filesystem)
+  set(source "
+    #include <filesystem>
+
+    int main()
+    {
+      (void)std::filesystem::current_path().root_name();
+    }
+  ")
+
+  include(CheckCXXSourceCompiles)
+  check_cxx_source_links("${source}" STD_FILESYSTEM_NO_EXTRA_LIBS_NEEDED)
+  if(STD_FILESYSTEM_NO_EXTRA_LIBS_NEEDED)
+    return()
+  endif()
+
+  add_library(std_filesystem INTERFACE)
+  check_cxx_source_links_with_libs(stdc++fs "${source}" STD_FILESYSTEM_NEEDS_LINK_TO_LIBSTDCXXFS)
+  if(STD_FILESYSTEM_NEEDS_LINK_TO_LIBSTDCXXFS)
+    target_link_libraries(std_filesystem INTERFACE stdc++fs)
+    return()
+  endif()
+  check_cxx_source_links_with_libs(c++fs "${source}" STD_FILESYSTEM_NEEDS_LINK_TO_LIBCXXFS)
+  if(STD_FILESYSTEM_NEEDS_LINK_TO_LIBCXXFS)
+    target_link_libraries(std_filesystem INTERFACE c++fs)
+    return()
+  endif()
+  message(FATAL_ERROR "Cannot figure out how to use std::filesystem.")
+endfunction()

--- a/cmake/secp256k1.cmake
+++ b/cmake/secp256k1.cmake
@@ -1,0 +1,48 @@
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# This file is part of the transition from Autotools to CMake. Once CMake
+# support has been merged we should switch to using the upstream CMake
+# buildsystem.
+
+set(CMAKE_C_STANDARD 90)
+set(CMAKE_C_EXTENSIONS OFF)
+
+include(CheckCSourceCompiles)
+check_c_source_compiles("
+  #include <stdint.h>
+
+  int main()
+  {
+    uint64_t a = 11, tmp;
+    __asm__ __volatile__(\"movq $0x100000000,%1; mulq %%rsi\" : \"+a\"(a) : \"S\"(tmp) : \"cc\", \"%rdx\");
+  }
+  " HAVE_64BIT_ASM
+)
+
+add_library(secp256k1 STATIC EXCLUDE_FROM_ALL
+  ${PROJECT_SOURCE_DIR}/src/secp256k1/src/secp256k1.c
+  ${PROJECT_SOURCE_DIR}/src/secp256k1/src/precomputed_ecmult.c
+  ${PROJECT_SOURCE_DIR}/src/secp256k1/src/precomputed_ecmult_gen.c
+)
+
+target_compile_definitions(secp256k1
+  PRIVATE
+    ECMULT_GEN_PREC_BITS=4
+    ECMULT_WINDOW_SIZE=15
+    ENABLE_MODULE_RECOVERY
+    ENABLE_MODULE_SCHNORRSIG
+    ENABLE_MODULE_EXTRAKEYS
+    $<$<BOOL:${HAVE_64BIT_ASM}>:USE_ASM_X86_64=1>
+)
+
+target_include_directories(secp256k1
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/secp256k1/include>
+)
+
+target_compile_options(secp256k1
+  PRIVATE
+    $<$<CXX_COMPILER_ID:MSVC>:/wd4146 /wd4334>
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,4 +6,5 @@ configure_file(${CMAKE_SOURCE_DIR}/cmake/bitcoin-config.h.in config/bitcoin-conf
 add_compile_definitions(HAVE_CONFIG_H)
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_subdirectory(crypto)
 add_subdirectory(univalue)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,3 +8,4 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_subdirectory(crypto)
 add_subdirectory(univalue)
+add_subdirectory(util)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,3 +5,5 @@
 configure_file(${CMAKE_SOURCE_DIR}/cmake/bitcoin-config.h.in config/bitcoin-config.h @ONLY)
 add_compile_definitions(HAVE_CONFIG_H)
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_subdirectory(univalue)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,3 +9,22 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 add_subdirectory(crypto)
 add_subdirectory(univalue)
 add_subdirectory(util)
+
+
+# Stable, backwards-compatible consensus functionality
+# also exposed as a shared library and/or a static one.
+add_library(bitcoin_consensus OBJECT EXCLUDE_FROM_ALL
+  arith_uint256.cpp
+  consensus/merkle.cpp
+  consensus/tx_check.cpp
+  hash.cpp
+  primitives/block.cpp
+  primitives/transaction.cpp
+  pubkey.cpp
+  script/interpreter.cpp
+  script/script.cpp
+  script/script_error.cpp
+  uint256.cpp
+  util/strencodings.cpp
+)
+target_link_libraries(bitcoin_consensus PRIVATE secp256k1)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,3 +28,176 @@ add_library(bitcoin_consensus OBJECT EXCLUDE_FROM_ALL
   util/strencodings.cpp
 )
 target_link_libraries(bitcoin_consensus PRIVATE secp256k1)
+
+
+# Home for common functionality shared by different executables and libraries.
+# Similar to `bitcoin_util` library, but higher-level.
+add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
+  base58.cpp
+  bech32.cpp
+  chainparams.cpp
+  coins.cpp
+  common/bloom.cpp
+  common/interfaces.cpp
+  common/run_command.cpp
+  $<$<TARGET_EXISTS:libevent::libevent>:common/url.cpp>
+  compressor.cpp
+  core_read.cpp
+  core_write.cpp
+  deploymentinfo.cpp
+  external_signer.cpp
+  init/common.cpp
+  key.cpp
+  key_io.cpp
+  merkleblock.cpp
+  net_types.cpp
+  netaddress.cpp
+  netbase.cpp
+  net_permissions.cpp
+  outputtype.cpp
+  policy/feerate.cpp
+  policy/policy.cpp
+  protocol.cpp
+  psbt.cpp
+  rpc/rawtransaction_util.cpp
+  rpc/request.cpp
+  rpc/external_signer.cpp
+  rpc/util.cpp
+  scheduler.cpp
+  script/descriptor.cpp
+  script/miniscript.cpp
+  script/sign.cpp
+  script/signingprovider.cpp
+  script/standard.cpp
+  warnings.cpp
+)
+target_compile_definitions(bitcoin_common
+  PRIVATE
+    ${THREAD_LOCAL_IF_AVAILABLE}
+)
+target_link_libraries(bitcoin_common
+  PRIVATE
+    bitcoin_consensus
+    bitcoin_util
+    univalue
+    secp256k1
+    Boost::headers
+    $<TARGET_NAME_IF_EXISTS:libevent::libevent>
+)
+
+
+# P2P and RPC server functionality used by `bitcoind` and `bitcoin-qt` executables.
+add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
+  addrdb.cpp
+  addrman.cpp
+  banman.cpp
+  blockencodings.cpp
+  blockfilter.cpp
+  chain.cpp
+  consensus/tx_verify.cpp
+  dbwrapper.cpp
+  deploymentstatus.cpp
+  flatfile.cpp
+  headerssync.cpp
+  httprpc.cpp
+  httpserver.cpp
+  i2p.cpp
+  index/base.cpp
+  index/blockfilterindex.cpp
+  index/coinstatsindex.cpp
+  index/txindex.cpp
+  init.cpp
+  kernel/chain.cpp
+  kernel/checks.cpp
+  kernel/coinstats.cpp
+  kernel/context.cpp
+  kernel/cs_main.cpp
+  kernel/mempool_persist.cpp
+  mapport.cpp
+  net.cpp
+  netgroup.cpp
+  net_processing.cpp
+  node/blockstorage.cpp
+  node/caches.cpp
+  node/chainstate.cpp
+  node/chainstatemanager_args.cpp
+  node/coin.cpp
+  node/coins_view_args.cpp
+  node/connection_types.cpp
+  node/context.cpp
+  node/database_args.cpp
+  node/eviction.cpp
+  node/interface_ui.cpp
+  node/interfaces.cpp
+  node/mempool_args.cpp
+  node/mempool_persist_args.cpp
+  node/miner.cpp
+  node/minisketchwrapper.cpp
+  node/psbt.cpp
+  node/transaction.cpp
+  node/txreconciliation.cpp
+  node/utxo_snapshot.cpp
+  node/validation_cache_args.cpp
+  noui.cpp
+  policy/fees.cpp
+  policy/fees_args.cpp
+  policy/packages.cpp
+  policy/rbf.cpp
+  policy/settings.cpp
+  pow.cpp
+  rest.cpp
+  rpc/blockchain.cpp
+  rpc/fees.cpp
+  rpc/mempool.cpp
+  rpc/mining.cpp
+  rpc/net.cpp
+  rpc/node.cpp
+  rpc/output_script.cpp
+  rpc/rawtransaction.cpp
+  rpc/server.cpp
+  rpc/server_util.cpp
+  rpc/signmessage.cpp
+  rpc/txoutproof.cpp
+  script/sigcache.cpp
+  shutdown.cpp
+  signet.cpp
+  timedata.cpp
+  torcontrol.cpp
+  txdb.cpp
+  txmempool.cpp
+  txorphanage.cpp
+  txrequest.cpp
+  validation.cpp
+  validationinterface.cpp
+  versionbits.cpp
+
+  dummywallet.cpp
+)
+target_link_libraries(bitcoin_node
+  PRIVATE
+    bitcoin_common
+    bitcoin_util
+    leveldb
+    minisketch
+    univalue
+    Boost::headers
+    libevent::libevent
+    $<TARGET_NAME_IF_EXISTS:PkgConfig::libevent_pthreads>
+)
+
+
+# Bitcoin Core bitcoind.
+if(BUILD_DAEMON)
+  add_executable(bitcoind
+    bitcoind.cpp
+    init/bitcoind.cpp
+  )
+  target_link_libraries(bitcoind
+    PRIVATE
+      bitcoin_node
+  )
+  target_link_options(bitcoind
+    PRIVATE
+      $<$<BOOL:${MINGW}>:-static>
+  )
+endif()

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -1,0 +1,122 @@
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+if(ASM AND NOT MSVC)
+  # Check for SSE4.1 intrinsics.
+  set(SSE41_CXXFLAGS -msse4.1)
+  check_cxx_source_compiles_with_flags("${SSE41_CXXFLAGS}" "
+    #include <immintrin.h>
+
+    int main()
+    {
+      __m128i l = _mm_set1_epi32(0);
+      return _mm_extract_epi32(l, 3);
+    }
+    " HAVE_SSE41
+  )
+
+  # Check for AVX2 intrinsics.
+  set(AVX2_CXXFLAGS -mavx -mavx2)
+  check_cxx_source_compiles_with_flags("${AVX2_CXXFLAGS}" "
+    #include <immintrin.h>
+
+    int main()
+    {
+      __m256i l = _mm256_set1_epi32(0);
+      return _mm256_extract_epi32(l, 7);
+    }
+    " HAVE_AVX2
+  )
+
+  # Check for x86 SHA-NI intrinsics.
+  set(X86_SHANI_CXXFLAGS -msse4 -msha)
+  check_cxx_source_compiles_with_flags("${X86_SHANI_CXXFLAGS}" "
+    #include <immintrin.h>
+
+    int main()
+    {
+      __m128i i = _mm_set1_epi32(0);
+      __m128i j = _mm_set1_epi32(1);
+      __m128i k = _mm_set1_epi32(2);
+      return _mm_extract_epi32(_mm_sha256rnds2_epu32(i, j, k), 0);
+    }
+    " HAVE_X86_SHANI
+  )
+
+  # Check for ARMv8 SHA-NI intrinsics.
+  set(ARM_SHANI_CXXFLAGS -march=armv8-a+crypto)
+  check_cxx_source_compiles_with_flags("${ARM_SHANI_CXXFLAGS}" "
+    #include <arm_neon.h>
+
+    int main()
+    {
+      uint32x4_t a, b, c;
+      vsha256h2q_u32(a, b, c);
+      vsha256hq_u32(a, b, c);
+      vsha256su0q_u32(a, b);
+      vsha256su1q_u32(a, b, c);
+    }
+    " HAVE_ARM_SHANI
+  )
+endif()
+
+include(CheckCXXSymbolExists)
+check_cxx_symbol_exists(timingsafe_bcmp "string.h" HAVE_TIMINGSAFE_BCMP)
+
+# The `bitcoin_crypto` must be of an `OBJECT` type to include
+# its object files into the output static library archives.
+add_library(bitcoin_crypto OBJECT EXCLUDE_FROM_ALL
+  $<$<BOOL:${ASM}>:sha256_sse4.cpp>
+  aes.cpp
+  chacha_poly_aead.cpp
+  chacha20.cpp
+  hkdf_sha256_32.cpp
+  hmac_sha256.cpp
+  hmac_sha512.cpp
+  poly1305.cpp
+  muhash.cpp
+  ripemd160.cpp
+  sha1.cpp
+  sha256.cpp
+  sha3.cpp
+  sha512.cpp
+  siphash.cpp
+)
+target_compile_definitions(bitcoin_crypto
+  PRIVATE
+    $<$<BOOL:${ASM}>:USE_ASM>
+    $<$<BOOL:${HAVE_SSE41}>:ENABLE_SSE41>
+    $<$<BOOL:${HAVE_AVX2}>:ENABLE_AVX2>
+    $<$<BOOL:${HAVE_X86_SHANI}>:ENABLE_X86_SHANI>
+    $<$<BOOL:${HAVE_ARM_SHANI}>:ENABLE_ARM_SHANI>
+    $<$<BOOL:${HAVE_TIMINGSAFE_BCMP}>:HAVE_TIMINGSAFE_BCMP>
+)
+
+if(HAVE_SSE41)
+  target_sources(bitcoin_crypto PRIVATE sha256_sse41.cpp)
+  set_property(SOURCE sha256_sse41.cpp
+    APPEND PROPERTY COMPILE_OPTIONS ${SSE41_CXXFLAGS}
+  )
+endif()
+
+if(HAVE_AVX2)
+  target_sources(bitcoin_crypto PRIVATE sha256_avx2.cpp)
+  set_property(SOURCE sha256_avx2.cpp
+    APPEND PROPERTY COMPILE_OPTIONS ${AVX2_CXXFLAGS}
+  )
+endif()
+
+if(HAVE_X86_SHANI)
+  target_sources(bitcoin_crypto PRIVATE sha256_x86_shani.cpp)
+  set_property(SOURCE sha256_x86_shani.cpp
+    APPEND PROPERTY COMPILE_OPTIONS ${X86_SHANI_CXXFLAGS}
+  )
+endif()
+
+if(HAVE_ARM_SHANI)
+  target_sources(bitcoin_crypto PRIVATE sha256_arm_shani.cpp)
+  set_property(SOURCE sha256_arm_shani.cpp
+    APPEND PROPERTY COMPILE_OPTIONS ${ARM_SHANI_CXXFLAGS}
+  )
+endif()

--- a/src/univalue/CMakeLists.txt
+++ b/src/univalue/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+add_library(univalue STATIC EXCLUDE_FROM_ALL
+  lib/univalue.cpp
+  lib/univalue_get.cpp
+  lib/univalue_read.cpp
+  lib/univalue_write.cpp
+)
+
+target_include_directories(univalue
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,0 +1,56 @@
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+add_library(bitcoin_util STATIC EXCLUDE_FROM_ALL
+  asmap.cpp
+  bip32.cpp
+  bytevectorhash.cpp
+  check.cpp
+  error.cpp
+  fees.cpp
+  getuniquepath.cpp
+  hasher.cpp
+  message.cpp
+  moneystr.cpp
+  rbf.cpp
+  readwritefile.cpp
+  settings.cpp
+  serfloat.cpp
+  sock.cpp
+  spanparsing.cpp
+  strencodings.cpp
+  string.cpp
+  syscall_sandbox.cpp
+  syserror.cpp
+  system.cpp
+  thread.cpp
+  threadinterrupt.cpp
+  threadnames.cpp
+  time.cpp
+  tokenpipe.cpp
+  ../chainparamsbase.cpp
+  ../clientversion.cpp
+  ../fs.cpp
+  ../logging.cpp
+  ../random.cpp
+  ../randomenv.cpp
+  ../support/cleanse.cpp
+  ../support/lockedpool.cpp
+  ../sync.cpp
+)
+
+target_compile_definitions(bitcoin_util
+  PRIVATE
+    ${THREAD_LOCAL_IF_AVAILABLE}
+    $<$<CXX_COMPILER_ID:MSVC>:_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING>
+)
+
+target_link_libraries(bitcoin_util
+  PRIVATE
+    bitcoin_crypto
+    univalue
+    Threads::Threads
+    $<TARGET_NAME_IF_EXISTS:std_filesystem>
+    $<$<BOOL:${MINGW}>:ws2_32>
+)


### PR DESCRIPTION
The parent PR: https://github.com/bitcoin/bitcoin/pull/25797.
The previous PRs in the staging branch: https://github.com/hebasto/bitcoin/pull/5, https://github.com/hebasto/bitcoin/pull/6.

This PR adds the `bitcoind` build target with its dependencies.

To get comparable binaries, one can use the following commands:
- with CMake:
```
cmake -S . -B build -DCMAKE_CXX_FLAGS="-g -O2"
cmake --build build
```
- with Autotools:
```
./autogen.sh
./configure --disable-hardening --disable-wallet --disable-zmq --without-miniupnpc --without-natpmp --disable-usdt
make clean
make -C src bitcoind
```
---

**Windows-specific notes for reviewers**

Windows MSVC builds use dependencies provided by the [vcpkg](https://vcpkg.io) package manager. To install them, run:
```cmd
vcpkg --triplet=x64-windows-static install boost-multi-index boost-signals2 libevent
```

To configure, a toolchain file and a triplet must be specified:
```cmd
cmake -G "Visual Studio 17 2022" -A x64 --toolchain C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static -S . -B build
```

Then, build the `all` target as usual:
```cmd
cmake --build build --config Debug
```