### PR TITLE
build: Add CMake-based build system (9 of N)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,9 @@ if(WIN32)
   if(MSVC)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     add_compile_options(/utf-8 /Zc:__cplusplus)
+    # Improve parallelism in MSBuild.
+    # See: https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/.
+    list(APPEND CMAKE_VS_GLOBALS "UseMultiToolTask=true")
   endif()
 
   if(MINGW)

--- a/cmake/optional.cmake
+++ b/cmake/optional.cmake
@@ -16,7 +16,6 @@ if(CCACHE)
       list(APPEND CMAKE_VS_GLOBALS
         "CLToolExe=${MSVC_CCACHE_WRAPPER_FILENAME}"
         "CLToolPath=${CMAKE_BINARY_DIR}"
-        "TrackFileAccess=false"
         "DebugInformationFormat=OldStyle"
       )
     else()

--- a/cmake/optional.cmake
+++ b/cmake/optional.cmake
@@ -13,11 +13,10 @@ if(CCACHE)
       set(MSVC_CCACHE_WRAPPER_CONTENT "\"${CCACHE_EXECUTABLE}\" \"${CMAKE_CXX_COMPILER}\"")
       set(MSVC_CCACHE_WRAPPER_FILENAME wrapped-cl.bat)
       file(WRITE ${CMAKE_BINARY_DIR}/${MSVC_CCACHE_WRAPPER_FILENAME} "${MSVC_CCACHE_WRAPPER_CONTENT} %*")
-      set(CMAKE_VS_GLOBALS
+      list(APPEND CMAKE_VS_GLOBALS
         "CLToolExe=${MSVC_CCACHE_WRAPPER_FILENAME}"
         "CLToolPath=${CMAKE_BINARY_DIR}"
         "TrackFileAccess=false"
-        "UseMultiToolTask=true"
         "DebugInformationFormat=OldStyle"
       )
     else()

--- a/cmake/optional.cmake
+++ b/cmake/optional.cmake
@@ -5,14 +5,14 @@
 # Optional features and packages.
 
 if(CCACHE)
-  find_program(CCACHE_EXECUTABLE ccache)
-  if(CCACHE_EXECUTABLE)
+  find_program(CCACHE_COMMAND ccache)
+  if(CCACHE_COMMAND)
     if(MSVC)
       if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
         # ccache >= 4.8 requires compile batching turned off that is available since CMake 3.24.
         # See https://github.com/ccache/ccache/wiki/MS-Visual-Studio
         set(CCACHE ON)
-        set(MSVC_CCACHE_WRAPPER_CONTENT "\"${CCACHE_EXECUTABLE}\" \"${CMAKE_CXX_COMPILER}\"")
+        set(MSVC_CCACHE_WRAPPER_CONTENT "\"${CCACHE_COMMAND}\" \"${CMAKE_CXX_COMPILER}\"")
         set(MSVC_CCACHE_WRAPPER_FILENAME wrapped-cl.bat)
         file(WRITE ${CMAKE_BINARY_DIR}/${MSVC_CCACHE_WRAPPER_FILENAME} "${MSVC_CCACHE_WRAPPER_CONTENT} %*")
         list(APPEND CMAKE_VS_GLOBALS
@@ -30,15 +30,15 @@ if(CCACHE)
       endif()
     else()
       set(CCACHE ON)
-      list(APPEND CMAKE_C_COMPILER_LAUNCHER ${CCACHE_EXECUTABLE})
-      list(APPEND CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_EXECUTABLE})
+      list(APPEND CMAKE_C_COMPILER_LAUNCHER ${CCACHE_COMMAND})
+      list(APPEND CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_COMMAND})
     endif()
   elseif(CCACHE STREQUAL "AUTO")
     set(CCACHE OFF)
   else()
     message(FATAL_ERROR "ccache requested, but not found.")
   endif()
-  mark_as_advanced(CCACHE_EXECUTABLE)
+  mark_as_advanced(CCACHE_COMMAND)
 endif()
 
 if(WITH_NATPMP)


### PR DESCRIPTION
The parent PR: https://github.com/bitcoin/bitcoin/pull/25797.
The previous PRs in the staging branch: https://github.com/hebasto/bitcoin/pull/5, https://github.com/hebasto/bitcoin/pull/6, https://github.com/hebasto/bitcoin/pull/7, https://github.com/hebasto/bitcoin/pull/10, https://github.com/hebasto/bitcoin/pull/13, https://github.com/hebasto/bitcoin/pull/15, https://github.com/hebasto/bitcoin/pull/17, https://github.com/hebasto/bitcoin/pull/18.

This PR consists of fixups related to using [Ccache](https://ccache.dev/) in MSVC builds.