### PR TITLE
cmake: Avoid overlinking

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -217,13 +217,9 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   validation.cpp
   validationinterface.cpp
   versionbits.cpp
+  $<$<TARGET_EXISTS:bitcoin_wallet>:wallet/init.cpp>
+  $<$<NOT:$<TARGET_EXISTS:bitcoin_wallet>>:dummywallet.cpp>
 )
-if(ENABLE_WALLET)
-  target_sources(bitcoin_node PRIVATE wallet/init.cpp)
-  target_link_libraries(bitcoin_node PRIVATE bitcoin_wallet)
-else()
-  target_sources(bitcoin_node PRIVATE dummywallet.cpp)
-endif()
 target_link_libraries(bitcoin_node
   PRIVATE
     core
@@ -250,6 +246,7 @@ if(BUILD_DAEMON)
   target_link_libraries(bitcoind
     core
     bitcoin_node
+    $<TARGET_NAME_IF_EXISTS:bitcoin_wallet>
   )
   list(APPEND installable_targets bitcoind)
 endif()

--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright (c) 2023 The Bitcoin Core developers
+# Copyright (c) 2023-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://opensource.org/license/mit/.
 
 include(GenerateHeaders)
 generate_header_from_raw(data/block413567.raw)
@@ -52,8 +52,7 @@ add_executable(bench_bitcoin
 target_link_libraries(bench_bitcoin
   core
   test_util
-  leveldb
-  univalue
+  bitcoin_node
   Boost::headers
 )
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright (c) 2023 The Bitcoin Core developers
+# Copyright (c) 2023-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://opensource.org/license/mit/.
 
 include(GenerateHeaders)
 generate_header_from_json(data/base58_encode_decode.json)
@@ -140,13 +140,8 @@ target_link_libraries(test_bitcoin
   test_util
   bitcoin_cli
   bitcoin_node
-  bitcoin_common
-  bitcoin_util
   minisketch
-  leveldb
-  univalue
   Boost::headers
-  libevent::libevent
 )
 
 if(ENABLE_WALLET)

--- a/src/test/util/CMakeLists.txt
+++ b/src/test/util/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright (c) 2023 The Bitcoin Core developers
+# Copyright (c) 2023-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://opensource.org/license/mit/.
 
 add_library(test_util STATIC EXCLUDE_FROM_ALL
   blockfilter.cpp
@@ -17,22 +17,13 @@ add_library(test_util STATIC EXCLUDE_FROM_ALL
   transaction_utils.cpp
   txmempool.cpp
   validation.cpp
+  $<$<BOOL:${ENABLE_WALLET}>:${PROJECT_SOURCE_DIR}/src/wallet/test/util.cpp>
 )
+
 target_link_libraries(test_util
   PRIVATE
     core
-    bitcoin_common
-    bitcoin_node
-    leveldb
-    univalue
     Boost::headers
+  PUBLIC
+    univalue
 )
-
-if(ENABLE_WALLET)
-  target_sources(test_util
-    PRIVATE
-      ../../wallet/test/util.cpp
-  )
-endif()
-
-target_link_libraries(test_util PRIVATE core)

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright (c) 2023 The Bitcoin Core developers
+# Copyright (c) 2023-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://opensource.org/license/mit/.
 
 add_library(bitcoin_util STATIC EXCLUDE_FROM_ALL
   asmap.cpp
@@ -53,7 +53,6 @@ target_link_libraries(bitcoin_util
   PRIVATE
     core
     bitcoin_crypto
-    univalue
     Threads::Threads
     $<$<BOOL:${MINGW}>:ws2_32>
 )

--- a/src/zmq/CMakeLists.txt
+++ b/src/zmq/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright (c) 2023 The Bitcoin Core developers
+# Copyright (c) 2023-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://opensource.org/license/mit/.
 
 add_library(bitcoin_zmq STATIC
   zmqabstractnotifier.cpp
@@ -16,7 +16,6 @@ target_compile_definitions(bitcoin_zmq
 target_link_libraries(bitcoin_zmq
   PRIVATE
     core
-    leveldb
     univalue
     $<TARGET_NAME_IF_EXISTS:libzmq>
     $<TARGET_NAME_IF_EXISTS:PkgConfig::libzmq>


### PR DESCRIPTION
Additionally, this PR fixes "ld: warning: ignoring duplicate libraries" on macOS:

```
[....] Linking CXX executable test_bitcoin
ld: warning: ignoring duplicate libraries: '../../libleveldb.a', '../libbitcoin_common.a', '../univalue/libunivalue.a', '../util/libbitcoin_util.a'
```
```
[....] Linking CXX executable bench_bitcoin
ld: warning: ignoring duplicate libraries: '../../libleveldb.a', '../univalue/libunivalue.a', '../wallet/libbitcoin_wallet.a'
```

The third [commit](https://github.com/hebasto/bitcoin/pull/34/commits/aaf50aced37909c9abf8605e928a5fb1eaa840f0) makes the `bitcoin_wallet` library a direct dependency of `bitcoind` rather `bitcoin_node`, that is outlined in  https://github.com/bitcoin/bitcoin/blob/master/doc/design/libraries.md.