### PR TITLE
cmake: Log more details about thread support

### DIFF
--- a/cmake/module/AddThreadsIfNeeded.cmake
+++ b/cmake/module/AddThreadsIfNeeded.cmake
@@ -19,6 +19,12 @@ function(add_threads_if_needed)
   find_package(Threads REQUIRED)
   set_target_properties(Threads::Threads PROPERTIES IMPORTED_GLOBAL TRUE)
 
+  if(CMAKE_THREAD_LIBS_INIT)
+    message(STATUS "  The thread library to use: ${CMAKE_THREAD_LIBS_INIT}")
+  else()
+    message(STATUS "  The thread functions are provided by the system libraries")
+  endif()
+
   set(thread_local)
   if(MINGW)
     #[=[


### PR DESCRIPTION
I found it very useful during extensive testing on a wide range of platforms.

For example,
- on Ubuntu 20.04, GCC 9.4.0:
```
-- Found Threads: TRUE  
--   The thread library to use: -pthread
```

- on Ubuntu 22.04, GCC 11.4.0:
```
-- Found Threads: TRUE  
--   The thread functions are provided by the system libraries
```