### PR TITLE
cmake: Rework searching for wallet dependencies

### DIFF
--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -246,7 +246,3 @@ check_cxx_source_compiles("
   int main(){}
   " HAVE_DLLEXPORT_ATTRIBUTE
 )
-
-if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
-  find_program(BREW_COMMAND brew)
-endif()

--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -246,3 +246,7 @@ check_cxx_source_compiles("
   int main(){}
   " HAVE_DLLEXPORT_ATTRIBUTE
 )
+
+if(CMAKE_HOST_APPLE)
+  find_program(BREW_COMMAND brew)
+endif()

--- a/cmake/module/FindBerkeleyDB.cmake
+++ b/cmake/module/FindBerkeleyDB.cmake
@@ -2,86 +2,128 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-if(CMAKE_HOST_APPLE)
+#[=======================================================================[
+FindBerkeleyDB
+--------------
+
+Finds the Berkeley DB headers and library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides imported target ``BerkeleyDB::BerkeleyDB``, if
+Berkeley DB has been found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+``BerkeleyDB_FOUND``
+  "True" if Berkeley DB found.
+
+``BerkeleyDB_VERSION``
+  The MAJOR.MINOR version of Berkeley DB found.
+
+#]=======================================================================]
+
+if(BREW_COMMAND)
+  # The Homebrew package manager installs the berkeley-db* packages as
+  # "keg-only", which means they are not symlinked into the default prefix.
+  # To find such a package, the find_path() and find_library() commands
+  # need additional path hints that are computed by Homebrew itself.
   execute_process(
-    COMMAND brew --prefix berkeley-db@4
-    OUTPUT_VARIABLE bdb4_brew_prefix
+    COMMAND ${BREW_COMMAND} --prefix berkeley-db@4
+    OUTPUT_VARIABLE _BerkeleyDB_homebrew_prefix
     ERROR_QUIET
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 endif()
 
 find_path(BerkeleyDB_INCLUDE_DIR
-  NAMES db.h
-  HINTS ${bdb4_brew_prefix}/include
-  PATH_SUFFIXES 4.8 48 4 db4 5 5.3 db5
+  NAMES db_cxx.h
+  HINTS ${_BerkeleyDB_homebrew_prefix}/include
+  PATH_SUFFIXES 4.8 48 4 db4 5.3 5 db5
 )
+mark_as_advanced(BerkeleyDB_INCLUDE_DIR)
+unset(_BerkeleyDB_homebrew_prefix)
 
-if(BerkeleyDB_INCLUDE_DIR)
-  file(
-    STRINGS "${BerkeleyDB_INCLUDE_DIR}/db.h" version_strings
-    REGEX ".*DB_VERSION_(MAJOR|MINOR)[ \t]+[0-9]+.*"
+if(NOT BerkeleyDB_LIBRARY)
+  if(VCPKG_TARGET_TRIPLET)
+    # The vcpkg package manager installs the berkeleydb package with the same name
+    # of release and debug libraries. Therefore, the default search paths set by
+    # vcpkg's toolchain file cannot be used to search libraries as the debug one
+    # will always be found.
+    set(CMAKE_FIND_USE_CMAKE_PATH FALSE)
+  endif()
+
+  get_filename_component(_BerkeleyDB_lib_hint "${BerkeleyDB_INCLUDE_DIR}" DIRECTORY)
+
+  find_library(BerkeleyDB_LIBRARY_RELEASE
+    NAMES db_cxx-4.8 db4_cxx db48 db_cxx-5.3 db_cxx-5 db_cxx libdb48
+    NAMES_PER_DIR
+    HINTS ${_BerkeleyDB_lib_hint}
+    PATH_SUFFIXES lib
   )
-  string(REGEX REPLACE ".*DB_VERSION_MAJOR[ \t]+([0-9]+).*" "\\1" BerkeleyDB_VERSION_MAJOR "${version_strings}")
-  string(REGEX REPLACE ".*DB_VERSION_MINOR[ \t]+([0-9]+).*" "\\1" BerkeleyDB_VERSION_MINOR "${version_strings}")
-  set(BerkeleyDB_VERSION ${BerkeleyDB_VERSION_MAJOR}.${BerkeleyDB_VERSION_MINOR})
+  mark_as_advanced(BerkeleyDB_LIBRARY_RELEASE)
+
+  find_library(BerkeleyDB_LIBRARY_DEBUG
+    NAMES db_cxx-4.8 db4_cxx db48 db_cxx-5.3 db_cxx-5 db_cxx libdb48
+    NAMES_PER_DIR
+    HINTS ${_BerkeleyDB_lib_hint}
+    PATH_SUFFIXES debug/lib
+  )
+  mark_as_advanced(BerkeleyDB_LIBRARY_DEBUG)
+
+  unset(_BerkeleyDB_lib_hint)
+  unset(CMAKE_FIND_USE_CMAKE_PATH)
+
+  include(SelectLibraryConfigurations)
+  select_library_configurations(BerkeleyDB)
+  # The select_library_configurations() command sets BerkeleyDB_FOUND, but we
+  # want the one from the find_package_handle_standard_args() command below.
+  unset(BerkeleyDB_FOUND)
 endif()
 
-if(MSVC)
-  cmake_path(GET BerkeleyDB_INCLUDE_DIR PARENT_PATH BerkeleyDB_IMPORTED_PATH)
-  find_library(BerkeleyDB_LIBRARY_DEBUG
-    NAMES libdb48 PATHS ${BerkeleyDB_IMPORTED_PATH}/debug/lib
-    NO_DEFAULT_PATH
-  )
-  find_library(BerkeleyDB_LIBRARY_RELEASE
-    NAMES libdb48 PATHS ${BerkeleyDB_IMPORTED_PATH}/lib
-    NO_DEFAULT_PATH
-  )
-  if(BerkeleyDB_LIBRARY_DEBUG OR BerkeleyDB_LIBRARY_RELEASE)
-    set(BerkeleyDB_required BerkeleyDB_IMPORTED_PATH)
-  endif()
-else()
-  find_library(BerkeleyDB_LIBRARY
-    NAMES db_cxx-4.8 libdb48 db4_cxx db_cxx db_cxx-5
-    HINTS ${bdb4_brew_prefix}/lib
-  )
-  set(BerkeleyDB_required BerkeleyDB_LIBRARY)
+if(BerkeleyDB_INCLUDE_DIR)
+  file(STRINGS "${BerkeleyDB_INCLUDE_DIR}/db.h" _BerkeleyDB_version_strings REGEX "^#define[\t ]+DB_VERSION_(MAJOR|MINOR|PATCH)[ \t]+[0-9]+.*")
+  string(REGEX REPLACE ".*#define[\t ]+DB_VERSION_MAJOR[ \t]+([0-9]+).*" "\\1" _BerkeleyDB_version_major "${_BerkeleyDB_version_strings}")
+  string(REGEX REPLACE ".*#define[\t ]+DB_VERSION_MINOR[ \t]+([0-9]+).*" "\\1" _BerkeleyDB_version_minor "${_BerkeleyDB_version_strings}")
+  string(REGEX REPLACE ".*#define[\t ]+DB_VERSION_PATCH[ \t]+([0-9]+).*" "\\1" _BerkeleyDB_version_patch "${_BerkeleyDB_version_strings}")
+  unset(_BerkeleyDB_version_strings)
+  # The MAJOR.MINOR.PATCH version will be logged in the following find_package_handle_standard_args() command.
+  set(_BerkeleyDB_full_version ${_BerkeleyDB_version_major}.${_BerkeleyDB_version_minor}.${_BerkeleyDB_version_patch})
+  set(BerkeleyDB_VERSION ${_BerkeleyDB_version_major}.${_BerkeleyDB_version_minor})
+  unset(_BerkeleyDB_version_major)
+  unset(_BerkeleyDB_version_minor)
+  unset(_BerkeleyDB_version_patch)
 endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(BerkeleyDB
-  REQUIRED_VARS ${BerkeleyDB_required} BerkeleyDB_INCLUDE_DIR
-  VERSION_VAR BerkeleyDB_VERSION
+  REQUIRED_VARS BerkeleyDB_LIBRARY BerkeleyDB_INCLUDE_DIR
+  VERSION_VAR _BerkeleyDB_full_version
 )
+unset(_BerkeleyDB_full_version)
 
 if(BerkeleyDB_FOUND AND NOT TARGET BerkeleyDB::BerkeleyDB)
   add_library(BerkeleyDB::BerkeleyDB UNKNOWN IMPORTED)
   set_target_properties(BerkeleyDB::BerkeleyDB PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${BerkeleyDB_INCLUDE_DIR}"
   )
-  if(MSVC)
-    if(BerkeleyDB_LIBRARY_DEBUG)
-      set_property(TARGET BerkeleyDB::BerkeleyDB APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
-      set_target_properties(BerkeleyDB::BerkeleyDB PROPERTIES
-        IMPORTED_LOCATION_DEBUG "${BerkeleyDB_LIBRARY_DEBUG}"
-      )
-    endif()
-    if(BerkeleyDB_LIBRARY_RELEASE)
-      set_property(TARGET BerkeleyDB::BerkeleyDB APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
-      set_target_properties(BerkeleyDB::BerkeleyDB PROPERTIES
-        IMPORTED_LOCATION_RELEASE "${BerkeleyDB_LIBRARY_RELEASE}"
-      )
-    endif()
-  else()
+  if(BerkeleyDB_LIBRARY_RELEASE)
+    set_property(TARGET BerkeleyDB::BerkeleyDB APPEND PROPERTY
+      IMPORTED_CONFIGURATIONS RELEASE
+    )
     set_target_properties(BerkeleyDB::BerkeleyDB PROPERTIES
-      IMPORTED_LOCATION "${BerkeleyDB_LIBRARY}"
+      IMPORTED_LOCATION_RELEASE "${BerkeleyDB_LIBRARY_RELEASE}"
+    )
+  endif()
+  if(BerkeleyDB_LIBRARY_DEBUG)
+    set_property(TARGET BerkeleyDB::BerkeleyDB APPEND PROPERTY
+      IMPORTED_CONFIGURATIONS DEBUG)
+    set_target_properties(BerkeleyDB::BerkeleyDB PROPERTIES
+      IMPORTED_LOCATION_DEBUG "${BerkeleyDB_LIBRARY_DEBUG}"
     )
   endif()
 endif()
-
-mark_as_advanced(
-  BerkeleyDB_INCLUDE_DIR
-  BerkeleyDB_LIBRARY
-  BerkeleyDB_LIBRARY_DEBUG
-  BerkeleyDB_LIBRARY_RELEASE
-)

--- a/cmake/optional.cmake
+++ b/cmake/optional.cmake
@@ -137,16 +137,13 @@ endif()
 
 if(ENABLE_WALLET)
   if(WITH_SQLITE)
-    # TODO: Consider using the FindSQLite3 module after bumping
-    # the minimum required CMake version up to 3.14+.
-    if(MSVC)
+    if(VCPKG_TARGET_TRIPLET)
       # Use of the `unofficial::` namespace is a vcpkg package manager convention.
       find_package(unofficial-sqlite3 CONFIG)
     else()
-      include(CrossPkgConfig)
-      cross_pkg_check_modules(sqlite3 sqlite3>=3.7.17 IMPORTED_TARGET)
+      find_package(SQLite3 3.7.17)
     endif()
-    if(TARGET unofficial::sqlite3::sqlite3 OR TARGET PkgConfig::sqlite3)
+    if(TARGET unofficial::sqlite3::sqlite3 OR TARGET SQLite::SQLite3)
       set(WITH_SQLITE ON)
       set(USE_SQLITE ON)
     elseif(WITH_SQLITE STREQUAL "AUTO")

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -48,7 +48,7 @@ if(USE_SQLITE)
   target_link_libraries(bitcoin_wallet
     PRIVATE
       $<TARGET_NAME_IF_EXISTS:unofficial::sqlite3::sqlite3>
-      $<TARGET_NAME_IF_EXISTS:PkgConfig::sqlite3>
+      $<TARGET_NAME_IF_EXISTS:SQLite::SQLite3>
   )
 endif()
 if(USE_BDB)


### PR DESCRIPTION
SQLite:
- Switching to CMake's [`FindSQLite3`](https://cmake.org/cmake/help/latest/module/FindSQLite3.html) module.

Berkeley DB:
- Our `FindBerkeleyDB` module has been rewritten using CMake guides and similar code from the CMake repo.
- It is compiler-agnostic now and properly handles corner cases with Homebrew and vcpkg package managers.