### PR TITLE
cmake: Silent MSVC warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,17 @@ if(WIN32)
     # Improve parallelism in MSBuild.
     # See: https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/.
     list(APPEND CMAKE_VS_GLOBALS "UseMultiToolTask=true")
+
+    try_append_cxx_flags("/W3" TARGET core)
+    try_append_cxx_flags("/wd4018" TARGET core)
+    try_append_cxx_flags("/wd4244" TARGET core)
+    try_append_cxx_flags("/wd4267" TARGET core)
+    try_append_cxx_flags("/wd4715" TARGET core)
+    try_append_cxx_flags("/wd4805" TARGET core)
+    target_compile_definitions(core INTERFACE
+      _CRT_SECURE_NO_WARNINGS
+      _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
+    )
   endif()
 
   if(MINGW)

--- a/cmake/leveldb.cmake
+++ b/cmake/leveldb.cmake
@@ -1,6 +1,6 @@
-# Copyright (c) 2023 The Bitcoin Core developers
+# Copyright (c) 2023-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://opensource.org/license/mit/.
 
 # This file is part of the transition from Autotools to CMake. Once CMake
 # support has been merged we should switch to using the upstream CMake
@@ -41,6 +41,8 @@ add_library(leveldb STATIC EXCLUDE_FROM_ALL
   ${PROJECT_SOURCE_DIR}/src/leveldb/util/comparator.cc
   ${PROJECT_SOURCE_DIR}/src/leveldb/util/crc32c.cc
   ${PROJECT_SOURCE_DIR}/src/leveldb/util/env.cc
+  $<$<NOT:$<BOOL:${WIN32}>>:${PROJECT_SOURCE_DIR}/src/leveldb/util/env_posix.cc>
+  $<$<BOOL:${WIN32}>:${PROJECT_SOURCE_DIR}/src/leveldb/util/env_windows.cc>
   ${PROJECT_SOURCE_DIR}/src/leveldb/util/filter_policy.cc
   ${PROJECT_SOURCE_DIR}/src/leveldb/util/hash.cc
   ${PROJECT_SOURCE_DIR}/src/leveldb/util/histogram.cc
@@ -49,14 +51,6 @@ add_library(leveldb STATIC EXCLUDE_FROM_ALL
   ${PROJECT_SOURCE_DIR}/src/leveldb/util/status.cc
   ${PROJECT_SOURCE_DIR}/src/leveldb/helpers/memenv/memenv.cc
 )
-if(WIN32)
-  target_sources(leveldb PRIVATE ${PROJECT_SOURCE_DIR}/src/leveldb/util/env_windows.cc)
-  set_property(SOURCE ${PROJECT_SOURCE_DIR}/src/leveldb/util/env_windows.cc
-    APPEND PROPERTY COMPILE_OPTIONS $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:Release>>:/wd4722>
-  )
-else()
-  target_sources(leveldb PRIVATE ${PROJECT_SOURCE_DIR}/src/leveldb/util/env_posix.cc)
-endif()
 
 target_compile_definitions(leveldb
   PRIVATE
@@ -67,19 +61,11 @@ target_compile_definitions(leveldb
     HAVE_O_CLOEXEC=$<BOOL:${HAVE_O_CLOEXEC}>
     FALLTHROUGH_INTENDED=[[fallthrough]]
     LEVELDB_IS_BIG_ENDIAN=${WORDS_BIGENDIAN}
+    $<$<NOT:$<BOOL:${WIN32}>>:LEVELDB_PLATFORM_POSIX>
+    $<$<BOOL:${WIN32}>:LEVELDB_PLATFORM_WINDOWS>
+    $<$<BOOL:${WIN32}>:_UNICODE;UNICODE>
+    $<$<BOOL:${MINGW}>:__USE_MINGW_ANSI_STDIO=1>
 )
-
-if(WIN32)
-  target_compile_definitions(leveldb
-    PRIVATE
-      LEVELDB_PLATFORM_WINDOWS
-      _UNICODE
-      UNICODE
-      __USE_MINGW_ANSI_STDIO=1
-  )
-else()
-  target_compile_definitions(leveldb PRIVATE LEVELDB_PLATFORM_POSIX)
-endif()
 
 target_include_directories(leveldb
   PRIVATE
@@ -87,6 +73,20 @@ target_include_directories(leveldb
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/leveldb/include>
 )
+
+if(MSVC)
+  target_compile_options(leveldb
+    PRIVATE
+      /wd4244
+      /wd4267
+      $<$<CONFIG:Release>:/wd4722>
+  )
+  target_compile_definitions(leveldb
+    PRIVATE
+      _CRT_NONSTDC_NO_DEPRECATE
+      _CRT_SECURE_NO_WARNINGS
+  )
+endif()
 
 #TODO: figure out how to filter out:
 # -Wconditional-uninitialized -Werror=conditional-uninitialized -Wsuggest-override -Werror=suggest-override

--- a/cmake/minisketch.cmake
+++ b/cmake/minisketch.cmake
@@ -1,6 +1,6 @@
-# Copyright (c) 2023 The Bitcoin Core developers
+# Copyright (c) 2023-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://opensource.org/license/mit/.
 
 # Check for clmul instructions support.
 if(MSVC)
@@ -24,12 +24,21 @@ check_cxx_source_compiles_with_flags("${CLMUL_CXXFLAGS}" "
   " HAVE_CLMUL
 )
 
-add_library(minisketch_defs INTERFACE)
-target_compile_definitions(minisketch_defs INTERFACE
+add_library(minisketch_common INTERFACE)
+target_compile_definitions(minisketch_common INTERFACE
   DISABLE_DEFAULT_FIELDS
   ENABLE_FIELD_32
   $<$<AND:$<BOOL:${HAVE_BUILTIN_CLZL}>,$<BOOL:${HAVE_BUILTIN_CLZLL}>>:HAVE_CLZ>
 )
+if(MSVC)
+  target_compile_options(minisketch_common INTERFACE
+    /wd4060
+    /wd4065
+    /wd4146
+    /wd4244
+    /wd4267
+  )
+endif()
 
 if(HAVE_CLMUL)
   add_library(minisketch_clmul OBJECT EXCLUDE_FROM_ALL
@@ -47,7 +56,7 @@ if(HAVE_CLMUL)
   target_link_libraries(minisketch_clmul
     PRIVATE
       core
-      minisketch_defs
+      minisketch_common
   )
 endif()
 
@@ -71,6 +80,6 @@ target_include_directories(minisketch
 target_link_libraries(minisketch
   PRIVATE
     core
-    minisketch_defs
+    minisketch_common
     $<TARGET_NAME_IF_EXISTS:minisketch_clmul>
 )

--- a/cmake/secp256k1.cmake
+++ b/cmake/secp256k1.cmake
@@ -1,6 +1,6 @@
-# Copyright (c) 2023 The Bitcoin Core developers
+# Copyright (c) 2023-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://opensource.org/license/mit/.
 
 # This file is part of the transition from Autotools to CMake. Once CMake
 # support has been merged we should switch to using the upstream CMake
@@ -48,9 +48,13 @@ target_include_directories(secp256k1
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/secp256k1/include>
 )
 
-target_compile_options(secp256k1
-  PRIVATE
-    $<$<CXX_COMPILER_ID:MSVC>:/wd4146 /wd4334>
-)
+if(MSVC)
+  target_compile_options(secp256k1
+    PRIVATE
+      /wd4146
+      /wd4244
+      /wd4267
+  )
+endif()
 
 target_link_libraries(secp256k1 PRIVATE core)


### PR DESCRIPTION
This PR follows the master branch approach and amends the previous commits.

Subtrees are treated separately from our code.

Also please refer to:
- https://github.com/hebasto/bitcoin/blob/953d302a242381ae13112ea42f87d57e6e796147/build_msvc/libleveldb/libleveldb.vcxproj#L54

- https://github.com/hebasto/bitcoin/blob/953d302a242381ae13112ea42f87d57e6e796147/build_msvc/libminisketch/libminisketch.vcxproj#L31

- https://github.com/hebasto/bitcoin/blob/953d302a242381ae13112ea42f87d57e6e796147/build_msvc/libsecp256k1/libsecp256k1.vcxproj#L20

- https://github.com/hebasto/bitcoin/blob/953d302a242381ae13112ea42f87d57e6e796147/build_msvc/common.init.vcxproj.in#L91-L93

- and https://github.com/bitcoin/bitcoin/pull/28798

All warning suppressions are documented,