### PR TITLE
cmake: Enable Unicode support for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,9 @@ if(WIN32)
   )
 
   if(MSVC)
+    target_compile_definitions(core INTERFACE
+      _UNICODE;UNICODE
+    )
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     target_compile_options(core INTERFACE
       /utf-8


### PR DESCRIPTION
Here are the compiler definitions for MSVC release builds:
- in the master branch:
```
/D _CONSOLE 
/D _CRT_SECURE_NO_WARNINGS 
/D HAVE_CONFIG_H 
/D NOMINMAX 
/D _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING 
/D _UNICODE
/D UNICODE 
/D WIN32 
/D _WIN32_IE=0x0501 
/D WIN32_LEAN_AND_MEAN
/D _WIN32_WINNT=0x0601 
```
- in the staging branch:
```
/D _CRT_SECURE_NO_WARNINGS 
/D HAVE_CONFIG_H 
/D _MBCS 
/D NOMINMAX 
/D _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING 
/D WIN32 
/D _WIN32_IE=0x0501 
/D WIN32_LEAN_AND_MEAN 
/D _WIN32_WINNT=0x0601 
/D _WINDOWS
```

The diff is:
```diff
-/D _CONSOLE
 /D _CRT_SECURE_NO_WARNINGS
 /D HAVE_CONFIG_H
+/D _MBCS
 /D NOMINMAX
 /D _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
-/D _UNICODE
-/D UNICODE
 /D WIN32
 /D _WIN32_IE=0x0501
 /D WIN32_LEAN_AND_MEAN
 /D _WIN32_WINNT=0x0601
+/D _WINDOWS
```

The PR eliminates discrepancies in the character set macros. The caveat is that we already use only Unicode variants of Windows functions. Therefore, I'm pretty sure it does not affect the resulted binaries. However, it requires more detailed scrutiny, which I left for the future.

Speaking of `/D _CONSOLE` and `/D _WINDOWS`, they looks like remnants of old VS versions and do nothing in VS 2022 we use to build Bitcoin Core. However, I might be wrong...