### PR TITLE
cmake: Redesign `bitcoin_crypto` and `bitcoin_consensus` libraries

### DIFF
--- a/cmake/module/CheckSourceCompilesAndLinks.cmake
+++ b/cmake/module/CheckSourceCompilesAndLinks.cmake
@@ -2,6 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
+include_guard(GLOBAL)
 include(CheckCXXSourceCompiles)
 include(CMakePushCheckState)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,9 +32,8 @@ add_subdirectory(univalue)
 add_subdirectory(util)
 
 
-# Stable, backwards-compatible consensus functionality
-# also exposed as a shared library and/or a static one.
-add_library(bitcoin_consensus OBJECT EXCLUDE_FROM_ALL
+add_library(bitcoin_consensus_sources INTERFACE)
+target_sources(bitcoin_consensus_sources INTERFACE
   arith_uint256.cpp
   consensus/merkle.cpp
   consensus/tx_check.cpp
@@ -48,9 +47,15 @@ add_library(bitcoin_consensus OBJECT EXCLUDE_FROM_ALL
   uint256.cpp
   util/strencodings.cpp
 )
+
+# Stable, backwards-compatible consensus functionality
+# also exposed as a shared library or a static one.
+add_library(bitcoin_consensus STATIC EXCLUDE_FROM_ALL)
 target_link_libraries(bitcoin_consensus
   PRIVATE
     core
+    bitcoin_consensus_sources
+    bitcoin_crypto
     secp256k1
 )
 

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -3,6 +3,8 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 if(ASM AND NOT MSVC)
+  include(CheckSourceCompilesAndLinks)
+
   # Check for SSE4.1 intrinsics.
   set(SSE41_CXXFLAGS -msse4.1)
   check_cxx_source_compiles_with_flags("${SSE41_CXXFLAGS}" "
@@ -64,10 +66,8 @@ endif()
 include(CheckCXXSymbolExists)
 check_cxx_symbol_exists(timingsafe_bcmp "string.h" HAVE_TIMINGSAFE_BCMP)
 
-# The `bitcoin_crypto` must be of an `OBJECT` type to include
-# its object files into the output static library archives.
-add_library(bitcoin_crypto OBJECT EXCLUDE_FROM_ALL
-  $<$<BOOL:${ASM}>:sha256_sse4.cpp>
+add_library(bitcoin_crypto_sources INTERFACE)
+target_sources(bitcoin_crypto_sources INTERFACE
   aes.cpp
   chacha20.cpp
   chacha20poly1305.cpp
@@ -79,24 +79,32 @@ add_library(bitcoin_crypto OBJECT EXCLUDE_FROM_ALL
   ripemd160.cpp
   sha1.cpp
   sha256.cpp
+  $<$<BOOL:${ASM}>:${CMAKE_CURRENT_SOURCE_DIR}/sha256_sse4.cpp>
   sha3.cpp
   sha512.cpp
   siphash.cpp
 )
+
+add_library(bitcoin_crypto STATIC EXCLUDE_FROM_ALL)
 target_compile_definitions(bitcoin_crypto
   PRIVATE
     $<$<BOOL:${ASM}>:USE_ASM>
-    $<$<BOOL:${HAVE_SSE41}>:ENABLE_SSE41>
-    $<$<BOOL:${HAVE_AVX2}>:ENABLE_AVX2>
-    $<$<BOOL:${HAVE_X86_SHANI}>:ENABLE_X86_SHANI>
-    $<$<BOOL:${HAVE_ARM_SHANI}>:ENABLE_ARM_SHANI>
     $<$<BOOL:${HAVE_TIMINGSAFE_BCMP}>:HAVE_TIMINGSAFE_BCMP>
+)
+target_link_libraries(bitcoin_crypto
+  PRIVATE
+    core
+    bitcoin_crypto_sources
 )
 
 if(HAVE_SSE41)
   target_sources(bitcoin_crypto PRIVATE sha256_sse41.cpp)
   set_property(SOURCE sha256_sse41.cpp
     APPEND PROPERTY COMPILE_OPTIONS ${SSE41_CXXFLAGS}
+  )
+  target_compile_definitions(bitcoin_crypto
+    PRIVATE
+      ENABLE_SSE41
   )
 endif()
 
@@ -105,12 +113,20 @@ if(HAVE_AVX2)
   set_property(SOURCE sha256_avx2.cpp
     APPEND PROPERTY COMPILE_OPTIONS ${AVX2_CXXFLAGS}
   )
+  target_compile_definitions(bitcoin_crypto
+    PRIVATE
+      ENABLE_AVX2
+  )
 endif()
 
 if(HAVE_X86_SHANI)
   target_sources(bitcoin_crypto PRIVATE sha256_x86_shani.cpp)
   set_property(SOURCE sha256_x86_shani.cpp
     APPEND PROPERTY COMPILE_OPTIONS ${X86_SHANI_CXXFLAGS}
+  )
+  target_compile_definitions(bitcoin_crypto
+    PRIVATE
+      ENABLE_X86_SHANI
   )
 endif()
 
@@ -119,6 +135,8 @@ if(HAVE_ARM_SHANI)
   set_property(SOURCE sha256_arm_shani.cpp
     APPEND PROPERTY COMPILE_OPTIONS ${ARM_SHANI_CXXFLAGS}
   )
+  target_compile_definitions(bitcoin_crypto
+    PRIVATE
+      ENABLE_ARM_SHANI
+  )
 endif()
-
-target_link_libraries(bitcoin_crypto PRIVATE core)


### PR DESCRIPTION
Source files of both `bitcoin_crypto` and `bitcoin_consensus` libraries factored out into interface libraries, which allows us to reuse them when compiling with different build options.

That is required to build upcoming shared libraries that, for example, use additional `-DBUILD_BITCOIN_INTERNAL` preprocessor flag.

No behavior change.

Split from https://github.com/hebasto/bitcoin/pull/41.

---

What to test:
1. Absence of behavior change.
2. The minimum supported CMake 3.16.