### PR TITLE
cmake: Add platform-specific compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ unset(check_pie_output)
 # It is intended to be a usage requirement for all other targets.
 add_library(core INTERFACE)
 
+include(TryAppendCXXFlags)
 include(TryAppendLinkerFlag)
 
 if(WIN32)
@@ -129,6 +130,12 @@ if(WIN32)
     # See: https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/.
     list(APPEND CMAKE_VS_GLOBALS "UseMultiToolTask=true")
 
+    try_append_cxx_flags("/W3" TARGET core)
+    try_append_cxx_flags("/wd4018" TARGET core)
+    try_append_cxx_flags("/wd4244" TARGET core)
+    try_append_cxx_flags("/wd4267" TARGET core)
+    try_append_cxx_flags("/wd4715" TARGET core)
+    try_append_cxx_flags("/wd4805" TARGET core)
     target_compile_definitions(core INTERFACE
       _CRT_SECURE_NO_WARNINGS
       _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
@@ -141,6 +148,9 @@ if(WIN32)
       _WINDOWS
       _MT
     )
+    # Avoid the use of aligned vector instructions when building for Windows.
+    # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54412.
+    try_append_cxx_flags("-Wa,-muse-unaligned-vector-move" TARGET core)
     try_append_linker_flag("-static" TARGET core)
     # We require Windows 7 (NT 6.1) or later.
     try_append_linker_flag("-Wl,--major-subsystem-version,6" TARGET core)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,6 @@ unset(check_pie_output)
 # It is intended to be a usage requirement for all other targets.
 add_library(core INTERFACE)
 
-include(TryAppendCXXFlags)
 include(TryAppendLinkerFlag)
 
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,12 +130,6 @@ if(WIN32)
     # See: https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/.
     list(APPEND CMAKE_VS_GLOBALS "UseMultiToolTask=true")
 
-    try_append_cxx_flags("/W3" TARGET core)
-    try_append_cxx_flags("/wd4018" TARGET core)
-    try_append_cxx_flags("/wd4244" TARGET core)
-    try_append_cxx_flags("/wd4267" TARGET core)
-    try_append_cxx_flags("/wd4715" TARGET core)
-    try_append_cxx_flags("/wd4805" TARGET core)
     target_compile_definitions(core INTERFACE
       _CRT_SECURE_NO_WARNINGS
       _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING


### PR DESCRIPTION
This PR mirrors https://github.com/hebasto/bitcoin/blob/d5e5810bd36f6e899d64a57e9264729b27a9c3f8/configure.ac#L720-L722

The "cmake: Add platform-specific compiler flags" commit is similar to 8f3a6454144b3b7aa70b38d99e79d7391bc9ec05 "cmake: Add platform-specific linker flags". And both those commits will be reordered in the next rebasing PR to be located next to each other.

---

Two fixup commits are required to fix the commit history as at some point the `try_append_cxx_flags` function is used without `include(TryAppendCXXFlags)`.

