### PR TITLE
cmake: Add a native build job on Ubuntu 20.04 + CMake 3.16

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -237,6 +237,7 @@ jobs:
 
       - name: Restore vcpkg binary cache
         uses: actions/cache/restore@v3
+        id: vcpkg-binary-cache
         with:
           path: ~/AppData/Local/vcpkg/archives
           key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-binary-${{ hashFiles('cmake_version', 'msbuild_version', 'toolset_version', 'vcpkg.json') }}
@@ -247,6 +248,7 @@ jobs:
 
       - name: Save vcpkg binary cache
         uses: actions/cache/save@v3
+        if: github.event_name != 'pull_request' && steps.vcpkg-binary-cache.outputs.cache-hit != 'true'
         with:
           path: ~/AppData/Local/vcpkg/archives
           key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-binary-${{ hashFiles('cmake_version', 'msbuild_version', 'toolset_version', 'vcpkg.json') }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -115,10 +115,15 @@ jobs:
         run: |
           cmake --build . -j $(nproc)
 
-      - name: Check
+      - name: Test
         working-directory: ./build
         run: |
           ctest -j $(nproc)
+
+      - name: Install
+        run: |
+          cmake --install build --prefix install
+          tree install
 
 
   cross-build:
@@ -197,9 +202,14 @@ jobs:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ matrix.host.triplet }}-ccache-${{ github.run_id }}
 
-      - name: Check
+      - name: Test
         run: |
           ctest --test-dir build -j $(nproc)
+
+      - name: Install
+        run: |
+          cmake --install build --prefix install
+          tree install
 
 
   win64-native-builtin-tools:
@@ -260,3 +270,8 @@ jobs:
       - name: Test Release configuration
         run: |
           ctest --test-dir build -j $env:NUMBER_OF_PROCESSORS -C Release
+
+      - name: Install Release configuration
+        run: |
+          cmake --install build --prefix install --config Release
+          tree /f install

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -79,6 +79,48 @@ jobs:
           diff -u src/obj/build.h build/src/obj/build.h
 
 
+  ubuntu-focal-native:
+    name: 'Ubuntu 20.04, CMake 3.16, Boost from depends'
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Remove preinstalled CMake
+        run: |
+          sudo rm /usr/local/bin/cmake /usr/local/bin/ctest
+
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends curl g++10 cmake libevent-dev libsqlite3-dev libdb-dev libdb++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev systemtap-sdt-dev
+
+      - name: CMake version
+        run: |
+          cmake --version
+          ctest --version
+
+      - name: Build Boost in depends
+        working-directory: ./depends
+        run: |
+          make -j $(nproc) NO_LIBEVENT=1 NO_QT=1 NO_WALLET=1 NO_NATPMP=1 NO_UPNP=1 NO_ZMQ=1 NO_USDT=1 ALLOW_HOST_PACKAGES=1 CC=gcc-10 CXX=g++-10
+
+      - name: Generate build system
+        run: |
+          cmake -B build -DCMAKE_TOOLCHAIN_FILE=depends/x86_64-pc-linux-gnu/share/toolchain.cmake -DENABLE_WALLET=ON -DWITH_NATPMP=ON -DWITH_MINIUPNPC=ON -DWITH_ZMQ=ON -DWITH_USDT=ON -DWERROR=ON
+
+      - name: Build
+        working-directory: ./build
+        run: |
+          cmake --build . -j $(nproc)
+
+      - name: Check
+        working-directory: ./build
+        run: |
+          ctest -j $(nproc)
+
+
   cross-build:
     name: ${{ matrix.host.name }}
     runs-on: ubuntu-22.04

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -4,9 +4,8 @@
 
 name: CMake
 on:
-  # See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request.
-  pull_request:
-  # See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push.
+  # Running for pushes is enough in the cmake-staging branch.
+  # pull_request:
   push:
     branches:
       - '**'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,7 +314,13 @@ if(WERROR)
 endif()
 
 find_package(Python3 3.9 COMPONENTS Interpreter)
-set(PYTHON_COMMAND ${Python3_EXECUTABLE})
+if(Python3_EXECUTABLE)
+  set(PYTHON_COMMAND ${Python3_EXECUTABLE})
+else()
+  list(APPEND configure_warnings
+    "Minimum required Python not found. Utils and rpcauth tests are disabled."
+  )
+endif()
 
 add_subdirectory(src)
 add_subdirectory(test)

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -1,18 +1,20 @@
-# Copyright (c) 2023 The Bitcoin Core developers
+# Copyright (c) 2023-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://opensource.org/license/mit/.
 
 include(CTest)
 
-if(TARGET bitcoin-util AND TARGET bitcoin-tx)
+if(TARGET bitcoin-util AND TARGET bitcoin-tx AND PYTHON_COMMAND)
   add_test(NAME util_test_runner
     COMMAND ${CMAKE_COMMAND} -E env BITCOINUTIL=$<TARGET_FILE:bitcoin-util> BITCOINTX=$<TARGET_FILE:bitcoin-tx> ${PYTHON_COMMAND} ${CMAKE_BINARY_DIR}/test/util/test_runner.py
   )
 endif()
 
-add_test(NAME util_rpcauth_test
-  COMMAND ${PYTHON_COMMAND} ${CMAKE_BINARY_DIR}/test/util/rpcauth-test.py
-)
+if(PYTHON_COMMAND)
+  add_test(NAME util_rpcauth_test
+    COMMAND ${PYTHON_COMMAND} ${CMAKE_BINARY_DIR}/test/util/rpcauth-test.py
+  )
+endif()
 
 if(TARGET bench_bitcoin)
   add_test(NAME bench_sanity_check_high_priority


### PR DESCRIPTION
This PR:
1. Adds a CI job that uses the minimum required CMake 3.16 and tests the `ALLOW_HOST_PACKAGES` depends feature.
2. Fixes tests when Pyrhon is not available.