### PR TITLE
cmake: Migrate Guix build scripts to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,6 +325,10 @@ add_subdirectory(test)
 
 include(cmake/tests.cmake)
 
+include(Maintenance)
+setup_split_debug_script()
+add_maintenance_targets()
+
 get_target_property(definitions core_interface INTERFACE_COMPILE_DEFINITIONS)
 separate_by_configs(definitions)
 

--- a/cmake/module/Maintenance.cmake
+++ b/cmake/module/Maintenance.cmake
@@ -1,0 +1,74 @@
+# Copyright (c) 2023-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+
+include_guard(GLOBAL)
+
+function(setup_split_debug_script)
+  if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
+    set(OBJCOPY ${CMAKE_OBJCOPY})
+    set(STRIP ${CMAKE_STRIP})
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.20)
+      configure_file(
+        contrib/devtools/split-debug.sh.in split-debug.sh
+        FILE_PERMISSIONS OWNER_READ OWNER_EXECUTE
+                         GROUP_READ GROUP_EXECUTE
+                         WORLD_READ
+        @ONLY
+      )
+    else()
+      configure_file(
+        contrib/devtools/split-debug.sh.in split-debug.sh
+        @ONLY
+      )
+    endif()
+  endif()
+endfunction()
+
+function(add_maintenance_targets)
+  if(NOT PYTHON_COMMAND)
+    return()
+  endif()
+
+  if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    set(exe_format MACHO)
+  elseif(WIN32)
+    set(exe_format PE)
+  else()
+    set(exe_format ELF)
+  endif()
+  if(CMAKE_CROSSCOMPILING)
+    list(JOIN DEPENDS_C_COMPILER_WITH_LAUNCHER " " c_compiler_command)
+  else()
+    set(c_compiler_command ${CMAKE_C_COMPILER})
+  endif()
+  add_custom_target(test-security-check
+    COMMAND ${CMAKE_COMMAND} -E env CC=${c_compiler_command} CFLAGS=${CMAKE_C_FLAGS} LDFLAGS=${CMAKE_EXE_LINKER_FLAGS} ${PYTHON_COMMAND} ${CMAKE_SOURCE_DIR}/contrib/devtools/test-security-check.py TestSecurityChecks.test_${exe_format}
+    COMMAND ${CMAKE_COMMAND} -E env CC=${c_compiler_command} CFLAGS=${CMAKE_C_FLAGS} LDFLAGS=${CMAKE_EXE_LINKER_FLAGS} ${PYTHON_COMMAND} ${CMAKE_SOURCE_DIR}/contrib/devtools/test-symbol-check.py TestSymbolChecks.test_${exe_format}
+    VERBATIM
+  )
+
+  foreach(target IN ITEMS bitcoind bitcoin-cli bitcoin-tx bitcoin-util bitcoin-wallet test_bitcoin bench_bitcoin)
+    if(TARGET ${target})
+      # Not using the TARGET_FILE generator expression because it creates excessive
+      # target-level dependencies in the following custom targets.
+      list(APPEND executables $<TARGET_FILE_DIR:${target}>/$<TARGET_FILE_NAME:${target}>)
+    endif()
+  endforeach()
+
+  add_custom_target(check-symbols
+    COMMAND ${CMAKE_COMMAND} -E echo "Running symbol and dynamic library checks..."
+    COMMAND ${PYTHON_COMMAND} ${CMAKE_SOURCE_DIR}/contrib/devtools/symbol-check.py ${executables}
+    VERBATIM
+  )
+
+  if(HARDENING)
+    add_custom_target(check-security
+      COMMAND ${CMAKE_COMMAND} -E echo "Checking binary security..."
+      COMMAND ${PYTHON_COMMAND} ${CMAKE_SOURCE_DIR}/contrib/devtools/security-check.py ${executables}
+      VERBATIM
+    )
+  else()
+    add_custom_target(check-security)
+  endif()
+endfunction()

--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -74,9 +74,11 @@ mkdir -p "$VERSION_BASE"
 ################
 
 # Default to building for all supported HOSTs (overridable by environment)
-export HOSTS="${HOSTS:-x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu powerpc64-linux-gnu powerpc64le-linux-gnu
-                       x86_64-w64-mingw32
-                       x86_64-apple-darwin arm64-apple-darwin}"
+# TODO: Re-enable Windows and macOS hosts.
+# export HOSTS="${HOSTS:-x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu powerpc64-linux-gnu powerpc64le-linux-gnu
+#                        x86_64-w64-mingw32
+#                        x86_64-apple-darwin arm64-apple-darwin}"
+export HOSTS="${HOSTS:-x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu powerpc64-linux-gnu powerpc64le-linux-gnu}"
 
 # Usage: distsrc_for_host HOST
 #

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -182,7 +182,9 @@ esac
 ####################
 
 # Build the depends tree, overriding variables that assume multilib gcc
+# TODO: Drop NO_QT=1
 make -C depends --jobs="$JOBS" HOST="$HOST" \
+                                   NO_QT=1 \
                                    ${V:+V=1} \
                                    ${SOURCES_PATH+SOURCES_PATH="$SOURCES_PATH"} \
                                    ${BASE_CACHE+BASE_CACHE="$BASE_CACHE"} \
@@ -215,7 +217,8 @@ mkdir -p "$OUTDIR"
 ###########################
 
 # CONFIGFLAGS
-CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests --disable-fuzz-binary"
+# TODO: Re-add CMake's analogue of --disable-gui-tests.
+CONFIGFLAGS="-DREDUCE_EXPORTS=ON -DBUILD_BENCH=OFF -DBUILD_FUZZ_BINARY=OFF"
 
 # CFLAGS
 HOST_CFLAGS="-O2 -g"
@@ -248,31 +251,23 @@ mkdir -p "$DISTSRC"
     # Extract the source tarball
     tar --strip-components=1 -xf "${GIT_ARCHIVE}"
 
-    ./autogen.sh
-
     # Configure this DISTSRC for $HOST
     # shellcheck disable=SC2086
-    env CONFIG_SITE="${BASEPREFIX}/${HOST}/share/config.site" \
-        ./configure --prefix=/ \
-                    --disable-ccache \
-                    --disable-maintainer-mode \
-                    --disable-dependency-tracking \
-                    ${CONFIGFLAGS} \
-                    ${HOST_CFLAGS:+CFLAGS="${HOST_CFLAGS}"} \
-                    ${HOST_CXXFLAGS:+CXXFLAGS="${HOST_CXXFLAGS}"} \
-                    ${HOST_LDFLAGS:+LDFLAGS="${HOST_LDFLAGS}"}
-
-    sed -i.old 's/-lstdc++ //g' config.status libtool
+    env CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}" LDFLAGS="${HOST_LDFLAGS}" \
+    cmake -S . -B build \
+          --toolchain "${BASEPREFIX}/${HOST}/share/toolchain.cmake" \
+          -DCCACHE=OFF \
+          ${CONFIGFLAGS}
 
     # Build Bitcoin Core
-    make --jobs="$JOBS" ${V:+V=1}
+    cmake --build build -j "$JOBS" ${V:+--verbose}
 
     # Check that symbol/security checks tools are sane.
-    make test-security-check ${V:+V=1}
+    cmake --build build --target test-security-check ${V:+--verbose}
     # Perform basic security checks on a series of executables.
-    make -C src --jobs=1 check-security ${V:+V=1}
+    cmake --build build -j 1 --target check-security ${V:+--verbose}
     # Check that executables only contain allowed version symbols.
-    make -C src --jobs=1 check-symbols  ${V:+V=1}
+    cmake --build build -j 1 --target check-symbols ${V:+--verbose}
 
     mkdir -p "$OUTDIR"
 
@@ -294,7 +289,7 @@ mkdir -p "$DISTSRC"
             make install-strip DESTDIR="${INSTALLPATH}" ${V:+V=1}
             ;;
         *)
-            make install DESTDIR="${INSTALLPATH}" ${V:+V=1}
+            cmake --install build --prefix "${INSTALLPATH}" ${V:+--verbose}
             ;;
     esac
 
@@ -327,21 +322,15 @@ mkdir -p "$DISTSRC"
                 ;;
         esac
 
-        # Prune libtool and object archives
-        find . -name "lib*.la" -delete
-        find . -name "lib*.a" -delete
-
-        # Prune pkg-config files
-        rm -rf "${DISTNAME}/lib/pkgconfig"
-
         case "$HOST" in
             *darwin*) ;;
             *)
                 # Split binaries and libraries from their debug symbols
+                # TODO: Re-enable code for libbitcoinkernel.
                 {
                     find "${DISTNAME}/bin" -type f -executable -print0
-                    find "${DISTNAME}/lib" -type f -print0
-                } | xargs -0 -P"$JOBS" -I{} "${DISTSRC}/contrib/devtools/split-debug.sh" {} {} {}.dbg
+                    # find "${DISTNAME}/lib" -type f -print0
+                } | xargs -0 -P"$JOBS" -I{} "${DISTSRC}/build/split-debug.sh" {} {} {}.dbg
                 ;;
         esac
 

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -499,6 +499,7 @@ inspecting signatures in Mach-O binaries.")
         gzip
         xz
         ;; Build tools
+        cmake-minimal
         gnu-make
         libtool
         autoconf-2.71
@@ -525,5 +526,5 @@ inspecting signatures in Mach-O binaries.")
           ((string-contains target "-linux-")
            (list (make-bitcoin-cross-toolchain target)))
           ((string-contains target "darwin")
-           (list clang-toolchain-17 binutils cmake-minimal python-signapple zip))
+           (list clang-toolchain-17 binutils python-signapple zip))
           (else '())))))


### PR DESCRIPTION
Windows and macOS hosts are disabled temporarily as they require GUI for their deploy targets.