### PR TITLE
cmake: Fix cross-compiling for Windows with `DEBUG=1`

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -167,6 +167,12 @@ jobs:
             packages: 'g++-mingw-w64-x86-64-posix'
             depends_options: 'NO_QT=1'
             exe_extension: '.exe'
+          - name: 'MinGW-w64, debug'
+            triplet: 'x86_64-w64-mingw32'
+            packages: 'g++-mingw-w64-x86-64-posix'
+            depends_options: 'NO_QT=1 DEBUG=1'
+            configure_options: '-DCMAKE_BUILD_TYPE=Debug'
+            exe_extension: '.exe'
 
     steps:
       - name: Checkout

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,10 @@ target_compile_definitions(bitcoin_clientversion
   PRIVATE
     HAVE_BUILD_INFO
 )
+target_link_libraries(bitcoin_clientversion
+  PRIVATE
+    core
+)
 add_dependencies(bitcoin_clientversion generate_build_info)
 
 add_subdirectory(crypto)


### PR DESCRIPTION
Also a dedicated CI job has been added to prevent any regression in the future.