### PR TITLE
cmake, ci: Add 'Test dependency search' CI job

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -79,6 +79,105 @@ jobs:
           diff -u src/obj/build.h build/src/obj/build.h
 
 
+  deps-search:
+    name: 'Test dependency search'
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        conf:
+          # Boost: Header-only. Using CMake's FindBoost module.
+          # Libevent: Using CMake's FindPkgConfig module.
+          - system_packages: ''
+            depends_options: 'NO_BOOST=1 NO_LIBEVENT=1 NO_WALLET=1 NO_USDT=1'
+            build_options: ''
+            expected: 'fail'
+          - system_packages: 'libboost-dev libevent-dev'
+            depends_options: 'NO_BOOST=1 NO_LIBEVENT=1 NO_WALLET=1 NO_USDT=1'
+            build_options: ''
+            expected: 'fail'
+          - system_packages: 'libboost-dev libevent-dev'
+            depends_options: 'NO_LIBEVENT=1 NO_WALLET=1 NO_USDT=1'
+            build_options: ''
+            expected: 'fail'
+          - system_packages: 'libboost-dev libevent-dev'
+            depends_options: 'NO_BOOST=1 NO_WALLET=1 NO_USDT=1'
+            build_options: ''
+            expected: 'fail'
+          - system_packages: 'libboost-dev libevent-dev'
+            depends_options: 'NO_WALLET=1 NO_USDT=1'
+            build_options: ''
+            expected: 'pass'
+
+          # BerkeleyDB: Using our own FindBerkeleyDB module.
+          - system_packages: 'libboost-dev libevent-dev'
+            depends_options: 'NO_BDB=1 NO_SQLITE=1 NO_USDT=1'
+            build_options: '-DWITH_BDB=ON'
+            expected: 'fail'
+          - system_packages: 'libboost-dev libevent-dev libdb-dev libdb++-dev'
+            depends_options: 'NO_BDB=1 NO_SQLITE=1 NO_USDT=1'
+            build_options: '-DWITH_BDB=ON'
+            expected: 'fail'
+          - system_packages: 'libboost-dev libevent-dev'
+            depends_options: 'NO_SQLITE=1 NO_USDT=1'
+            build_options: '-DWITH_BDB=ON'
+            expected: 'pass'
+
+          # SQLite: Using CMake's FindSQLite3 module.
+          - system_packages: 'libboost-dev libevent-dev'
+            depends_options: 'NO_BDB=1 NO_SQLITE=1 NO_USDT=1'
+            build_options: '-DWITH_SQLITE=ON'
+            expected: 'fail'
+          - system_packages: 'libboost-dev libevent-dev libsqlite3-dev'
+            depends_options: 'NO_BDB=1 NO_SQLITE=1 NO_USDT=1'
+            build_options: '-DWITH_SQLITE=ON'
+            expected: 'fail'
+          - system_packages: 'libboost-dev libevent-dev'
+            depends_options: 'NO_BDB=1 NO_USDT=1'
+            build_options: '-DWITH_SQLITE=ON'
+            expected: 'pass'
+
+          # USDT: Header-only. Using CMake's find_path function.
+          - system_packages: 'libboost-dev libevent-dev'
+            depends_options: 'NO_WALLET=1 NO_USDT=1'
+            build_options: '-DWITH_USDT=ON'
+            expected: 'fail'
+          - system_packages: 'libboost-dev libevent-dev systemtap-sdt-dev'
+            depends_options: 'NO_WALLET=1 NO_USDT=1'
+            build_options: '-DWITH_USDT=ON'
+            expected: 'fail'
+          - system_packages: 'libboost-dev libevent-dev'
+            depends_options: 'NO_WALLET=1'
+            build_options: '-DWITH_USDT=ON'
+            expected: 'pass'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install system packages
+        if: ${{ matrix.conf.system_packages != '' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends ${{ matrix.conf.system_packages }}
+
+      - name: Build depends
+        working-directory: depends
+        run: |
+          make -j $(nproc) ${{ matrix.conf.depends_options }} NO_QT=1 NO_ZMQ=1 NO_UPNP=1 NO_NATPMP=1 LOG=1
+
+      - name: Generate build system. Expected to FAIL
+        if: ${{ matrix.conf.expected == 'fail' }}
+        run: |
+          ! cmake -B build -DCMAKE_TOOLCHAIN_FILE=depends/x86_64-pc-linux-gnu/share/toolchain.cmake ${{ matrix.conf.build_options }}
+
+      - name: Generate build system. Expected to PASS
+        if: ${{ matrix.conf.expected == 'pass' }}
+        run: |
+          cmake -B build -DCMAKE_TOOLCHAIN_FILE=depends/x86_64-pc-linux-gnu/share/toolchain.cmake
+
+
   ubuntu-focal-native:
     name: 'Ubuntu 20.04, CMake 3.16, Boost from depends'
     runs-on: ubuntu-20.04


### PR DESCRIPTION
I've been working on a branch, which adds Qt stuff to the CMake-based build system.

However, it is possible that the package search code refactoring will be needed. Therefore, I'd like to get these CI tests in the staging branch to avoid any regressions.