### PR TITLE
cmake: Add UniValue tests to the `ctest` suit

### DIFF
--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -55,3 +55,15 @@ if(TARGET test_bitcoin)
 
   add_all_test_targets()
 endif()
+
+if(TARGET unitester)
+  add_test(NAME univalue_test
+    COMMAND unitester
+  )
+endif()
+
+if(TARGET object)
+  add_test(NAME univalue_object_test
+    COMMAND object
+  )
+endif()

--- a/src/univalue/CMakeLists.txt
+++ b/src/univalue/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright (c) 2023 The Bitcoin Core developers
+# Copyright (c) 2023-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://opensource.org/license/mit/.
 
 add_library(univalue STATIC EXCLUDE_FROM_ALL
   lib/univalue.cpp
@@ -8,10 +8,26 @@ add_library(univalue STATIC EXCLUDE_FROM_ALL
   lib/univalue_read.cpp
   lib/univalue_write.cpp
 )
-
 target_include_directories(univalue
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
-
 target_link_libraries(univalue PRIVATE core_interface)
+
+add_executable(unitester test/unitester.cpp)
+target_compile_definitions(unitester
+  PRIVATE
+    JSON_TEST_SRC=\"${CMAKE_CURRENT_SOURCE_DIR}/test\"
+)
+target_link_libraries(unitester
+  PRIVATE
+    core_interface
+    univalue
+)
+
+add_executable(object test/object.cpp)
+target_link_libraries(object
+  PRIVATE
+    core_interface
+    univalue
+)


### PR DESCRIPTION
As it was pointed out by **TheCharlatan** and **fanquake** during the recent offline meeting, since https://github.com/bitcoin/bitcoin/pull/25369, the Univalue unit tests must be included to the `ctest` suit.