### PR TITLE
cmake: Re-add Windows host to Guix scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,7 @@ include(cmake/tests.cmake)
 include(Maintenance)
 setup_split_debug_script()
 add_maintenance_targets()
+add_windows_deploy_target()
 
 get_target_property(definitions core_interface INTERFACE_COMPILE_DEFINITIONS)
 separate_by_configs(definitions)

--- a/cmake/module/AddWindowsResources.cmake
+++ b/cmake/module/AddWindowsResources.cmake
@@ -1,0 +1,14 @@
+# Copyright (c) 2024-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+
+include_guard(GLOBAL)
+
+macro(add_windows_resources target rc_file)
+  if(WIN32)
+    target_sources(${target} PRIVATE ${rc_file})
+    set_property(SOURCE ${rc_file}
+      APPEND PROPERTY COMPILE_DEFINITIONS WINDRES_PREPROC
+    )
+  endif()
+endmacro()

--- a/cmake/module/GenerateSetupNsi.cmake
+++ b/cmake/module/GenerateSetupNsi.cmake
@@ -1,0 +1,22 @@
+# Copyright (c) 2023-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+
+function(generate_setup_nsi)
+  set(abs_top_srcdir ${PROJECT_SOURCE_DIR})
+  set(abs_top_builddir ${PROJECT_BINARY_DIR})
+  set(PACKAGE_VERSION ${PROJECT_VERSION})
+  set(CLIENT_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
+  set(CLIENT_VERSION_MINOR ${PROJECT_VERSION_MINOR})
+  set(CLIENT_VERSION_BUILD ${PROJECT_VERSION_PATCH})
+  set(PACKAGE_URL ${PROJECT_HOMEPAGE_URL})
+  set(PACKAGE_TARNAME "bitcoin")
+  set(BITCOIN_GUI_NAME "bitcoin-qt")
+  set(BITCOIN_DAEMON_NAME "bitcoind")
+  set(BITCOIN_CLI_NAME "bitcoin-cli")
+  set(BITCOIN_TX_NAME "bitcoin-tx")
+  set(BITCOIN_WALLET_TOOL_NAME "bitcoin-wallet")
+  set(BITCOIN_TEST_NAME "test_bitcoin")
+  set(EXEEXT ${CMAKE_EXECUTABLE_SUFFIX})
+  configure_file(${PROJECT_SOURCE_DIR}/share/setup.nsi.in ${PROJECT_BINARY_DIR}/bitcoin-win64-setup.nsi @ONLY)
+endfunction()

--- a/cmake/module/Maintenance.cmake
+++ b/cmake/module/Maintenance.cmake
@@ -72,3 +72,26 @@ function(add_maintenance_targets)
     add_custom_target(check-security)
   endif()
 endfunction()
+
+function(add_windows_deploy_target)
+  if(MINGW AND TARGET bitcoin-qt AND TARGET bitcoind AND TARGET bitcoin-cli AND TARGET bitcoin-tx AND TARGET bitcoin-wallet AND TARGET bitcoin-util AND TARGET test_bitcoin)
+    # TODO: Consider replacing this code with the CPack NSIS Generator.
+    #       See https://cmake.org/cmake/help/latest/cpack_gen/nsis.html
+    include(GenerateSetupNsi)
+    generate_setup_nsi()
+    add_custom_command(
+      OUTPUT ${CMAKE_BINARY_DIR}/bitcoin-win64-setup.exe
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/release
+      COMMAND ${CMAKE_STRIP} $<TARGET_FILE:bitcoin-qt> -o ${CMAKE_BINARY_DIR}/release/$<TARGET_FILE_NAME:bitcoin-qt>
+      COMMAND ${CMAKE_STRIP} $<TARGET_FILE:bitcoind> -o ${CMAKE_BINARY_DIR}/release/$<TARGET_FILE_NAME:bitcoind>
+      COMMAND ${CMAKE_STRIP} $<TARGET_FILE:bitcoin-cli> -o ${CMAKE_BINARY_DIR}/release/$<TARGET_FILE_NAME:bitcoin-cli>
+      COMMAND ${CMAKE_STRIP} $<TARGET_FILE:bitcoin-tx> -o ${CMAKE_BINARY_DIR}/release/$<TARGET_FILE_NAME:bitcoin-tx>
+      COMMAND ${CMAKE_STRIP} $<TARGET_FILE:bitcoin-wallet> -o ${CMAKE_BINARY_DIR}/release/$<TARGET_FILE_NAME:bitcoin-wallet>
+      COMMAND ${CMAKE_STRIP} $<TARGET_FILE:bitcoin-util> -o ${CMAKE_BINARY_DIR}/release/$<TARGET_FILE_NAME:bitcoin-util>
+      COMMAND ${CMAKE_STRIP} $<TARGET_FILE:test_bitcoin> -o ${CMAKE_BINARY_DIR}/release/$<TARGET_FILE_NAME:test_bitcoin>
+      COMMAND makensis -V2 ${CMAKE_BINARY_DIR}/bitcoin-win64-setup.nsi
+      VERBATIM
+    )
+    add_custom_target(deploy DEPENDS ${CMAKE_BINARY_DIR}/bitcoin-win64-setup.exe)
+  endif()
+endfunction()

--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -74,11 +74,12 @@ mkdir -p "$VERSION_BASE"
 ################
 
 # Default to building for all supported HOSTs (overridable by environment)
-# TODO: Re-enable Windows and macOS hosts.
+# TODO: Re-enable macOS hosts.
 # export HOSTS="${HOSTS:-x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu powerpc64-linux-gnu powerpc64le-linux-gnu
 #                        x86_64-w64-mingw32
 #                        x86_64-apple-darwin arm64-apple-darwin}"
-export HOSTS="${HOSTS:-x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu powerpc64-linux-gnu powerpc64le-linux-gnu}"
+export HOSTS="${HOSTS:-x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu powerpc64-linux-gnu powerpc64le-linux-gnu
+                       x86_64-w64-mingw32}"
 
 # Usage: distsrc_for_host HOST
 #

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -272,7 +272,8 @@ mkdir -p "$DISTSRC"
     # Make the os-specific installers
     case "$HOST" in
         *mingw*)
-            make deploy ${V:+V=1} BITCOIN_WIN_INSTALLER="${OUTDIR}/${DISTNAME}-win64-setup-unsigned.exe"
+            cmake --build build -j "$JOBS" -t deploy ${V:+--verbose}
+            mv build/bitcoin-win64-setup.exe "${OUTDIR}/${DISTNAME}-win64-setup-unsigned.exe"
             ;;
     esac
 
@@ -316,7 +317,8 @@ mkdir -p "$DISTSRC"
 
         case "$HOST" in
             *mingw*)
-                mv --target-directory="$DISTNAME"/lib/ "$DISTNAME"/bin/*.dll
+                # TODO: Re-enable code for libbitcoinkernel.
+                # mv --target-directory="$DISTNAME"/lib/ "$DISTNAME"/bin/*.dll
                 ;;
         esac
 
@@ -388,7 +390,7 @@ mkdir -p "$DISTSRC"
 
     case "$HOST" in
         *mingw*)
-            cp -rf --target-directory=. contrib/windeploy
+            cp -rf --target-directory=. "${DISTSRC}/contrib/windeploy"
             (
                 cd ./windeploy
                 mkdir -p unsigned

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 include(GNUInstallDirs)
+include(AddWindowsResources)
 
 configure_file(${CMAKE_SOURCE_DIR}/cmake/bitcoin-config.h.in config/bitcoin-config.h @ONLY)
 add_compile_definitions(HAVE_CONFIG_H)
@@ -141,6 +142,7 @@ if(ENABLE_WALLET)
       init/bitcoin-wallet.cpp
       wallet/wallettool.cpp
     )
+    add_windows_resources(bitcoin-wallet bitcoin-wallet-res.rc)
     target_link_libraries(bitcoin-wallet
       core_interface
       bitcoin_wallet
@@ -270,6 +272,7 @@ if(BUILD_DAEMON)
     bitcoind.cpp
     init/bitcoind.cpp
   )
+  add_windows_resources(bitcoind bitcoind-res.rc)
   target_link_libraries(bitcoind
     core_interface
     bitcoin_node
@@ -293,6 +296,7 @@ target_link_libraries(bitcoin_cli
 # Bitcoin Core RPC client
 if(BUILD_CLI)
   add_executable(bitcoin-cli bitcoin-cli.cpp)
+  add_windows_resources(bitcoin-cli bitcoin-cli-res.rc)
   target_link_libraries(bitcoin-cli
     core_interface
     bitcoin_cli
@@ -306,6 +310,7 @@ endif()
 
 if(BUILD_TX)
   add_executable(bitcoin-tx bitcoin-tx.cpp)
+  add_windows_resources(bitcoin-tx bitcoin-tx-res.rc)
   target_link_libraries(bitcoin-tx
     core_interface
     bitcoin_common
@@ -318,6 +323,7 @@ endif()
 
 if(BUILD_UTIL)
   add_executable(bitcoin-util bitcoin-util.cpp)
+  add_windows_resources(bitcoin-util bitcoin-util-res.rc)
   target_link_libraries(bitcoin-util
     core_interface
     bitcoin_common

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -156,6 +156,8 @@ add_executable(bitcoin-qt
   ../init/bitcoin-qt.cpp
 )
 
+add_windows_resources(bitcoin-qt res/bitcoin-qt-res.rc)
+
 target_link_libraries(bitcoin-qt
   core_interface
   bitcoinqt


### PR DESCRIPTION
The Windows installer produced by the `deploy` target is named now `bitcoin-win64-setup.exe`, which differs from the master branch where it is `bitcoin-<VERSION>-win64-setup.exe`. I think, it is more consistent as other build artifacts do not have versioned names.

Guix build:
```
x86_64
c8c04ef3b212650b6121231325353fa490a1a0660e2e9964acc5712f16a279ee  guix-build-f56f5b914480/output/dist-archive/bitcoin-f56f5b914480.tar.gz
97d7b8b509576dc649d252b5b1f54148ed46bd7550acb7b2bf52c47acb9b2b16  guix-build-f56f5b914480/output/x86_64-w64-mingw32/SHA256SUMS.part
1df6445ebb26c973fdca643a3547bea2e1640791ef606354a2d0d06795eacbba  guix-build-f56f5b914480/output/x86_64-w64-mingw32/bitcoin-f56f5b914480-win64-debug.zip
3b95cb0c55f946bdc0f5921651444b3b0dae724e39f8e4a8278cbe8ce02dfd62  guix-build-f56f5b914480/output/x86_64-w64-mingw32/bitcoin-f56f5b914480-win64-setup-unsigned.exe
24cf0efd5e0c83704c2485dfea0ab826158005706e4fd15d6aa19afa2bb8e622  guix-build-f56f5b914480/output/x86_64-w64-mingw32/bitcoin-f56f5b914480-win64-unsigned.tar.gz
13c488d8faea7c7eab198b34edb851219f39e0caa9fc15e8ae6168ba646ea23f  guix-build-f56f5b914480/output/x86_64-w64-mingw32/bitcoin-f56f5b914480-win64.zip
```
