### PR TITLE
cmake: Add missed defintion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,24 +75,6 @@ option(BUILD_BENCH "Build bench_bitcoin executable." ON)
 cmake_dependent_option(BUILD_FUZZ_BINARY "Build fuzz binary." ON "NOT MSVC" OFF)
 cmake_dependent_option(FUZZ "Build for fuzzing. Enabling this will disable all other targets and override BUILD_FUZZ_BINARY." OFF "NOT MSVC" OFF)
 
-if(FUZZ)
-  message(WARNING "FUZZ=ON will disable all other targets and force BUILD_FUZZ_BINARY=ON.")
-  set(BUILD_DAEMON OFF)
-  set(BUILD_CLI OFF)
-  set(BUILD_TX OFF)
-  set(BUILD_UTIL OFF)
-  set(BUILD_UTIL_CHAINSTATE OFF)
-  set(BUILD_SHARED_LIBS OFF)
-  set(BUILD_WALLET_TOOL OFF)
-  set(WITH_GUI OFF)
-  set(WITH_NATPMP OFF)
-  set(WITH_MINIUPNPC OFF)
-  set(WITH_ZMQ OFF)
-  set(BUILD_TESTS OFF)
-  set(BUILD_BENCH OFF)
-  set(BUILD_FUZZ_BINARY ON)
-endif()
-
 option(INSTALL_MAN "Install man pages." ON)
 
 set(configure_warnings)
@@ -111,6 +93,28 @@ unset(check_pie_output)
 # The core_interface library aims to encapsulate common build flags.
 # It is intended to be a usage requirement for all other targets.
 add_library(core_interface INTERFACE)
+
+if(FUZZ)
+  message(WARNING "FUZZ=ON will disable all other targets and force BUILD_FUZZ_BINARY=ON.")
+  set(BUILD_DAEMON OFF)
+  set(BUILD_CLI OFF)
+  set(BUILD_TX OFF)
+  set(BUILD_UTIL OFF)
+  set(BUILD_UTIL_CHAINSTATE OFF)
+  set(BUILD_SHARED_LIBS OFF)
+  set(BUILD_WALLET_TOOL OFF)
+  set(WITH_GUI OFF)
+  set(WITH_NATPMP OFF)
+  set(WITH_MINIUPNPC OFF)
+  set(WITH_ZMQ OFF)
+  set(BUILD_TESTS OFF)
+  set(BUILD_BENCH OFF)
+  set(BUILD_FUZZ_BINARY ON)
+
+  target_compile_definitions(core_interface INTERFACE
+    ABORT_ON_FAILED_ASSUME
+  )
+endif()
 
 include(TryAppendCXXFlags)
 include(TryAppendLinkerFlag)


### PR DESCRIPTION
The `ABORT_ON_FAILED_ASSUME` preprocessor definition was overlooked.

It comes from https://github.com/hebasto/bitcoin/blob/9eeee7caa3f95ee17a645e12d330261f8e3c2dbf/configure.ac#L1298

Noticed while testing the https://github.com/hebasto/bitcoin/pull/82 in OSS-Fuzz.