### PR TITLE
cmake: Add preset for MSVC build

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -408,7 +408,7 @@ jobs:
 
       - name: Generate build system
         run: |
-          cmake -B build -A x64 --toolchain $env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static -DWITH_NATPMP=OFF
+          cmake -B build --preset vs2022
 
       - name: Save vcpkg binary cache
         uses: actions/cache/save@v4

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,22 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {"major": 3, "minor": 21, "patch": 0},
+  "configurePresets": [
+    {
+      "name": "vs2022",
+      "displayName": "Build using 'Visual Studio 17 2022' generator",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "generator": "Visual Studio 17 2022",
+      "architecture": "x64",
+      "toolchainFile": "$env{VCPKG_ROOT}\\scripts\\buildsystems\\vcpkg.cmake",
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "x64-windows-static",
+        "WITH_NATPMP": "OFF"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR improves the user experience when building on Windows.

As Visual Studio 17 2022 is minimum [required](https://github.com/bitcoin/bitcoin/blob/master/build_msvc/README.md) to build Bitcoin Core, it is safe to [assume](https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2017%202022.html) that CMake version is not older than 3.21. Moreover, the latest VS 17.8.6 ships CMake 3.27.2.