### PR TITLE
cmake: Improve Ccache usage on Windows

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -406,6 +406,10 @@ jobs:
           path: ~/AppData/Local/vcpkg/archives
           key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-binary-${{ hashFiles('cmake_version', 'msbuild_version', 'toolset_version', 'vcpkg.json') }}
 
+      - name: Install Ccache
+        run: |
+          choco install --yes --no-progress ccache
+
       - name: Generate build system
         run: |
           cmake -B build -A x64 --toolchain $env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static -DWITH_NATPMP=OFF
@@ -417,9 +421,30 @@ jobs:
           path: ~/AppData/Local/vcpkg/archives
           key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-binary-${{ hashFiles('cmake_version', 'msbuild_version', 'toolset_version', 'vcpkg.json') }}
 
+      - name: Restore Ccache cache
+        id: ccache-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/AppData/Local/ccache
+          key: ${{ github.job }}-ccache-${{ github.run_id }}
+          restore-keys: ${{ github.job }}-ccache-
+
       - name: Build Release configuration
         run: |
+          ccache --zero-stats
           cmake --build build -j $env:NUMBER_OF_PROCESSORS --config Release
+
+      - name: Ccache stats
+        run: |
+          ccache --version | head -n 1
+          ccache --show-stats --verbose
+
+      - name: Save Ccache cache
+        uses: actions/cache/save@v4
+        if: github.event_name != 'pull_request' && steps.ccache-cache.outputs.cache-hit != 'true'
+        with:
+          path: ~/AppData/Local/ccache
+          key: ${{ github.job }}-ccache-${{ github.run_id }}
 
       - name: Test Release configuration
         run: |


### PR DESCRIPTION
This PR:

1. Improves the user experience when using the `ccache` package installed via [Chocolatey](https://community.chocolatey.org/packages/ccache) on Windows. The new approach is the same as the one currently used in the master branch CI.

2. Also fix caching for debug configurations (see https://github.com/ccache/ccache/wiki/MS-Visual-Studio#usage-with-cmake)

3. Added caching to the "Win64 native" CI job:
- https://github.com/hebasto/bitcoin/actions/runs/7828761172/job/21362637142

(it might be compared with the log for the same branch, but without the first commit: https://github.com/hebasto/bitcoin/actions/runs/7828850714/job/21363047274)