### PR TITLE
cmake: Follow-up on PR74

### DIFF
--- a/cmake/module/TryAppendCXXFlags.cmake
+++ b/cmake/module/TryAppendCXXFlags.cmake
@@ -102,7 +102,7 @@ function(try_append_cxx_flags flags)
     set(${TACXXF_RESULT_VAR} "${${result}}" PARENT_SCOPE)
   endif()
 
-  if(TACXXF_SKIP_LINK)
+  if(NOT ${result} OR TACXXF_SKIP_LINK)
     return()
   endif()
 


### PR DESCRIPTION
This PR is a follow-up on https://github.com/hebasto/bitcoin/pull/74.

No need to try a flag in the linker context if it is not supported in the compiler context.

For example, on the staging branch:
```
$ env CC=clang CXX=clang++ cmake -B build
...
-- Performing Test CXX_SUPPORTS__FSTACK_REUSE_NONE
-- Performing Test CXX_SUPPORTS__FSTACK_REUSE_NONE - Failed
CMake Warning at cmake/module/TryAppendCXXFlags.cmake:125 (message):
  The -fstack-reuse=none fail(s) to link.
Call Stack (most recent call first):
  CMakeLists.txt:310 (try_append_cxx_flags)


...
```