### PR TITLE
cmake: Silent `leveldb`-specific warnings

### DIFF
--- a/cmake/leveldb.cmake
+++ b/cmake/leveldb.cmake
@@ -74,21 +74,23 @@ target_include_directories(leveldb
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/leveldb/include>
 )
 
+add_library(nowarn_leveldb_interface INTERFACE)
 if(MSVC)
-  target_compile_options(leveldb
-    PRIVATE
-      /wd4244
-      /wd4267
-      $<$<CONFIG:Release>:/wd4722>
+  target_compile_options(nowarn_leveldb_interface INTERFACE
+    /wd4722
   )
-  target_compile_definitions(leveldb
-    PRIVATE
-      _CRT_NONSTDC_NO_DEPRECATE
-      _CRT_SECURE_NO_WARNINGS
+  target_compile_definitions(nowarn_leveldb_interface INTERFACE
+    _CRT_NONSTDC_NO_WARNINGS
+  )
+else()
+  target_compile_options(nowarn_leveldb_interface INTERFACE
+    -Wno-conditional-uninitialized
+    -Wno-suggest-override
   )
 endif()
 
-#TODO: figure out how to filter out:
-# -Wconditional-uninitialized -Werror=conditional-uninitialized -Wsuggest-override -Werror=suggest-override
-
-target_link_libraries(leveldb PRIVATE core_interface crc32c)
+target_link_libraries(leveldb PRIVATE
+  core_interface
+  nowarn_leveldb_interface
+  crc32c
+)


### PR DESCRIPTION
This PR split from https://github.com/hebasto/bitcoin/pull/84

It introduces a new `warn_leveldb_interface`, which overrides `-Wconditional-uninitialized` and `-Wsuggest-override` if any.

For MSVC builds, dropped warning suppressions that are provided at the global level.

For example, on the staging branch:
```
$ env CC=clang CXX=clang++ CXXFLAGS="-Wconditional-uninitialized -Wsuggest-override" cmake -B build
$ cmake --build build --target leveldb > /dev/null 
/home/hebasto/git/bitcoin/src/leveldb/db/c.cc:474:17: warning: 'Name' overrides a member function but is not marked 'override' [-Wsuggest-override]
    const char* Name() const { return rep_->Name(); }
                ^
/home/hebasto/git/bitcoin/src/leveldb/db/c.cc:110:15: note: overridden virtual function is here
  const char* Name() const override { return (*name_)(state_); }
              ^
/home/hebasto/git/bitcoin/src/leveldb/db/c.cc:475:10: warning: 'CreateFilter' overrides a member function but is not marked 'override' [-Wsuggest-override]
    void CreateFilter(const Slice* keys, int n, std::string* dst) const {
         ^
/home/hebasto/git/bitcoin/src/leveldb/db/c.cc:112:8: note: overridden virtual function is here
  void CreateFilter(const Slice* keys, int n, std::string* dst) const override {
       ^
/home/hebasto/git/bitcoin/src/leveldb/db/c.cc:478:10: warning: 'KeyMayMatch' overrides a member function but is not marked 'override' [-Wsuggest-override]
    bool KeyMayMatch(const Slice& key, const Slice& filter) const {
         ^
/home/hebasto/git/bitcoin/src/leveldb/db/c.cc:125:8: note: overridden virtual function is here
  bool KeyMayMatch(const Slice& key, const Slice& filter) const override {
       ^
3 warnings generated.
/home/hebasto/git/bitcoin/src/leveldb/db/version_set.cc:1016:55: warning: variable 'manifest_size' may be uninitialized when used here [-Wconditional-uninitialized]
  descriptor_log_ = new log::Writer(descriptor_file_, manifest_size);
                                                      ^~~~~~~~~~~~~
/home/hebasto/git/bitcoin/src/leveldb/db/version_set.cc:997:25: note: initialize the variable 'manifest_size' to silence this warning
  uint64_t manifest_size;
                        ^
                         = 0
1 warning generated.
```