### PR TITLE
[BUGFIX] cmake: Fix `HAVE_THREAD_LOCAL` macro visibility

### DIFF
--- a/cmake/module/AddThreadsIfNeeded.cmake
+++ b/cmake/module/AddThreadsIfNeeded.cmake
@@ -19,7 +19,6 @@ function(add_threads_if_needed)
   find_package(Threads REQUIRED)
   set_target_properties(Threads::Threads PROPERTIES IMPORTED_GLOBAL TRUE)
 
-  set(thread_local)
   if(MINGW)
     #[=[
     mingw32's implementation of thread_local has been shown to behave
@@ -36,7 +35,8 @@ function(add_threads_if_needed)
      - https://groups.google.com/d/msg/bsdmailinglist/22ncTZAbDp4/Dii_pII5AwAJ
     ]=]
   elseif(THREADLOCAL)
-    set(thread_local "$<$<COMPILE_FEATURES:cxx_thread_local>:HAVE_THREAD_LOCAL>")
+    target_compile_definitions(core_interface INTERFACE
+      "$<$<COMPILE_FEATURES:cxx_thread_local>:HAVE_THREAD_LOCAL>"
+    )
   endif()
-  set(THREAD_LOCAL_IF_AVAILABLE "${thread_local}" PARENT_SCOPE)
 endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,10 +116,6 @@ add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
   script/solver.cpp
   warnings.cpp
 )
-target_compile_definitions(bitcoin_common
-  PRIVATE
-    ${THREAD_LOCAL_IF_AVAILABLE}
-)
 target_link_libraries(bitcoin_common
   PRIVATE
     core_interface

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -43,7 +43,6 @@ add_library(bitcoin_util STATIC EXCLUDE_FROM_ALL
 
 target_compile_definitions(bitcoin_util
   PRIVATE
-    ${THREAD_LOCAL_IF_AVAILABLE}
     $<$<CXX_COMPILER_ID:MSVC>:_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING>
 )
 


### PR DESCRIPTION
The `HAVE_THREAD_LOCAL` is not visible in `src/test/util_threadnames_tests.cpp`. It is easy to verify with the diff as follows:
```diff
--- a/src/test/util_threadnames_tests.cpp
+++ b/src/test/util_threadnames_tests.cpp
@@ -55,6 +55,7 @@ std::set<std::string> RenameEnMasse(int num_threads)
 BOOST_AUTO_TEST_CASE(util_threadnames_test_rename_threaded)
 {
 #if !defined(HAVE_THREAD_LOCAL)
+#error
     // This test doesn't apply to platforms where we don't have thread_local.
     return;
 #endif
```

This PR fixes this issue by moving the macro definition to the `core_interface` library.

Split from https://github.com/hebasto/bitcoin/pull/84.