### PR TITLE
cmake: Fix some "uninitialized variable" warnings

### DIFF
--- a/cmake/leveldb.cmake
+++ b/cmake/leveldb.cmake
@@ -64,8 +64,13 @@ target_compile_definitions(leveldb
     $<$<NOT:$<BOOL:${WIN32}>>:LEVELDB_PLATFORM_POSIX>
     $<$<BOOL:${WIN32}>:LEVELDB_PLATFORM_WINDOWS>
     $<$<BOOL:${WIN32}>:_UNICODE;UNICODE>
-    $<$<BOOL:${MINGW}>:__USE_MINGW_ANSI_STDIO=1>
 )
+if(MINGW)
+  target_compile_definitions(leveldb
+    PRIVATE
+      __USE_MINGW_ANSI_STDIO=1
+  )
+endif()
 
 target_include_directories(leveldb
   PRIVATE

--- a/cmake/module/AddLibeventIfNeeded.cmake
+++ b/cmake/module/AddLibeventIfNeeded.cmake
@@ -46,10 +46,14 @@ function(add_libevent_if_needed)
     REQUIRED IMPORTED_TARGET GLOBAL
     libevent>=${libevent_minimum_version}
   )
+  if(MINGW)
+    target_link_libraries(PkgConfig::libevent INTERFACE
+      iphlpapi
+      ws2_32
+    )
+  endif()
+
   check_evhttp_connection_get_peer(PkgConfig::libevent)
-  target_link_libraries(PkgConfig::libevent INTERFACE
-    $<$<BOOL:${MINGW}>:iphlpapi;ws2_32>
-  )
   add_library(libevent::libevent ALIAS PkgConfig::libevent)
 
   if(NOT WIN32)

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -53,5 +53,10 @@ target_link_libraries(bitcoin_util
     bitcoin_clientversion
     bitcoin_crypto
     Threads::Threads
-    $<$<BOOL:${MINGW}>:ws2_32>
 )
+if(MINGW)
+  target_link_libraries(bitcoin_util
+    PRIVATE
+      ws2_32
+  )
+endif()


### PR DESCRIPTION
The `MINGW` variable [might](https://cmake.org/cmake/help/latest/variable/MINGW.html) be uninitialized:
> Otherwise, this variable is not set by CMake.

OTOH, the `$<BOOL:string>` generator expression [expects](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#genex:BOOL) a (defined) string as its argument.

This causes "uninitialized variable" warnings enabled by `--warn-uninitialized` CMake's command line option.

This PR resolves this issue (but not all warnings).