### PR TITLE
cmake: Do not interfere with Qt plugin handling

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -137,7 +137,6 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
       fi
     fi
 
-    AC_DEFINE([QT_STATICPLUGIN], [1], [Define this symbol if qt plugins are static])
     if test "$TARGET_OS" != "android"; then
       _BITCOIN_QT_CHECK_STATIC_PLUGIN([QMinimalIntegrationPlugin], [-lqminimal])
       AC_DEFINE([QT_QPA_PLATFORM_MINIMAL], [1], [Define this symbol if the minimal qt platform exists])

--- a/build_msvc/bitcoin_config.h.in
+++ b/build_msvc/bitcoin_config.h.in
@@ -133,9 +133,6 @@
 /* Define this symbol if the qt platform is windows */
 #define QT_QPA_PLATFORM_WINDOWS 1
 
-/* Define this symbol if qt plugins are static */
-#define QT_STATICPLUGIN 1
-
 /* Windows Universal Platform constraints */
 #if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
 /* Either a desktop application without API restrictions, or and older system

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -2,6 +2,23 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
+function(import_plugins target)
+  if(CMAKE_CROSSCOMPILING OR VCPKG_TARGET_TRIPLET MATCHES "-static")
+    set(plugins Qt5::QMinimalIntegrationPlugin)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+      list(APPEND plugins Qt5::QXcbIntegrationPlugin)
+    elseif(WIN32)
+      list(APPEND plugins Qt5::QWindowsIntegrationPlugin Qt5::QWindowsVistaStylePlugin)
+    elseif(APPLE)
+      list(APPEND plugins Qt5::QCocoaIntegrationPlugin Qt5::QMacStylePlugin)
+    endif()
+    qt5_import_plugins(${target}
+        INCLUDE ${plugins}
+        EXCLUDE_BY_TYPE imageformats iconengines
+    )
+  endif()
+endfunction()
+
 # See:
 #  - https://cmake.org/cmake/help/latest/manual/cmake-qt.7.html
 #  - https://doc.qt.io/qt-5/cmake-manual.html
@@ -140,14 +157,12 @@ if(ENABLE_WALLET)
   )
 endif()
 
-if(CMAKE_CROSSCOMPILING)
-  if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND TARGET Qt5::QXcbIntegrationPlugin)
-    target_compile_definitions(bitcoinqt PRIVATE QT_QPA_PLATFORM_XCB)
-  elseif(WIN32 AND TARGET Qt5::QWindowsIntegrationPlugin AND TARGET Qt5::QWindowsVistaStylePlugin)
-    target_compile_definitions(bitcoinqt PRIVATE QT_QPA_PLATFORM_WINDOWS)
-  elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND TARGET Qt5::QCocoaIntegrationPlugin AND TARGET Qt5::QMacStylePlugin)
-    target_compile_definitions(bitcoinqt PRIVATE QT_QPA_PLATFORM_COCOA)
-  endif()
+if(CMAKE_CROSSCOMPILING OR VCPKG_TARGET_TRIPLET MATCHES "-static")
+  # We want to define static plugins to link ourselves, thus preventing
+  # automatic linking against a "sane" set of default static plugins.
+  qt5_import_plugins(bitcoinqt
+      EXCLUDE_BY_TYPE bearer iconengines imageformats platforms styles
+  )
 endif()
 
 add_executable(bitcoin-qt
@@ -162,6 +177,8 @@ target_link_libraries(bitcoin-qt
   bitcoinqt
   bitcoin_node
 )
+
+import_plugins(bitcoin-qt)
 
 if(WIN32)
   set_target_properties(bitcoin-qt PROPERTIES WIN32_EXECUTABLE TRUE)

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -141,7 +141,6 @@ if(ENABLE_WALLET)
 endif()
 
 if(CMAKE_CROSSCOMPILING)
-  target_compile_definitions(bitcoinqt PRIVATE QT_STATICPLUGIN)
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND TARGET Qt5::QXcbIntegrationPlugin)
     target_compile_definitions(bitcoinqt PRIVATE QT_QPA_PLATFORM_XCB)
   elseif(WIN32 AND TARGET Qt5::QWindowsIntegrationPlugin AND TARGET Qt5::QWindowsVistaStylePlugin)

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -62,7 +62,7 @@
 #include <QTranslator>
 #include <QWindow>
 
-#if defined(QT_STATICPLUGIN)
+#if defined(QT_STATIC)
 #include <QtPlugin>
 #if defined(QT_QPA_PLATFORM_XCB)
 Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -62,21 +62,6 @@
 #include <QTranslator>
 #include <QWindow>
 
-#if defined(QT_STATIC)
-#include <QtPlugin>
-#if defined(QT_QPA_PLATFORM_XCB)
-Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
-#elif defined(QT_QPA_PLATFORM_WINDOWS)
-Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
-Q_IMPORT_PLUGIN(QWindowsVistaStylePlugin);
-#elif defined(QT_QPA_PLATFORM_COCOA)
-Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin);
-Q_IMPORT_PLUGIN(QMacStylePlugin);
-#elif defined(QT_QPA_PLATFORM_ANDROID)
-Q_IMPORT_PLUGIN(QAndroidPlatformIntegrationPlugin)
-#endif
-#endif
-
 // Declare meta types used for QMetaObject::invokeMethod
 Q_DECLARE_METATYPE(bool*)
 Q_DECLARE_METATYPE(CAmount)

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -916,12 +916,7 @@ void LogQtInfo()
 #else
     const std::string qt_link{"dynamic"};
 #endif
-#ifdef QT_STATICPLUGIN
-    const std::string plugin_link{"static"};
-#else
-    const std::string plugin_link{"dynamic"};
-#endif
-    LogPrintf("Qt %s (%s), plugin=%s (%s)\n", qVersion(), qt_link, QGuiApplication::platformName().toStdString(), plugin_link);
+    LogPrintf("Qt %s (%s), plugin=%s\n", qVersion(), qt_link, QGuiApplication::platformName().toStdString());
     const auto static_plugins = QPluginLoader::staticPlugins();
     if (static_plugins.empty()) {
         LogPrintf("No static plugins.\n");

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -28,7 +28,7 @@
 
 #include <functional>
 
-#if defined(QT_STATICPLUGIN)
+#if defined(QT_STATIC)
 #include <QtPlugin>
 #if defined(QT_QPA_PLATFORM_MINIMAL)
 Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin);

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -28,22 +28,6 @@
 
 #include <functional>
 
-#if defined(QT_STATIC)
-#include <QtPlugin>
-#if defined(QT_QPA_PLATFORM_MINIMAL)
-Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin);
-#endif
-#if defined(QT_QPA_PLATFORM_XCB)
-Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
-#elif defined(QT_QPA_PLATFORM_WINDOWS)
-Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
-#elif defined(QT_QPA_PLATFORM_COCOA)
-Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin);
-#elif defined(QT_QPA_PLATFORM_ANDROID)
-Q_IMPORT_PLUGIN(QAndroidPlatformIntegrationPlugin)
-#endif
-#endif
-
 const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
 
 const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS{};


### PR DESCRIPTION
1. When using CMake, each plugin comes with a C++ stub file that automatically initializes the static plugin. Consequently, any target that links against a plugin has this C++ file added to its `SOURCES`, which makes the removed code redundant and [duplicates](https://github.com/hebasto/bitcoin/pull/103#issuecomment-1971889904) the included plugins. For example, on the staging branch @ 1a976ca427caa9ead411b605e49b673b2a16802c:
```
2024-03-01T10:51:26Z Bitcoin Core version v26.99.0-1a976ca427ca (release build)
2024-03-01T10:51:26Z Qt 5.15.11 (static), plugin=windows (static)
2024-03-01T10:51:26Z Static plugins:
2024-03-01T10:51:26Z  QWindowsIntegrationPlugin, version 331520
2024-03-01T10:51:26Z  QWindowsVistaStylePlugin, version 331520
2024-03-01T10:51:26Z  QWindowsVistaStylePlugin, version 331520
2024-03-01T10:51:26Z  QWindowsIntegrationPlugin, version 331520
2024-03-01T10:51:26Z Style: windowsvista / QWindowsVistaStyle
2024-03-01T10:51:26Z System: Windows 11 Version 2009, x86_64-little_endian-llp64
2024-03-01T10:51:26Z Screen: \\.\DISPLAY1 1920x1080, pixel ratio=1.0
```

Initially noticed in https://github.com/hebasto/bitcoin/pull/101#pullrequestreview-1898691050.

Here are `LogQtInfo()` outputs in the `debug.log`:
- `x86_64-pc-linux-gnu`:
```
2024-02-25T10:15:18Z Qt 5.15.11 (static), plugin=xcb (static)
2024-02-25T10:15:18Z Static plugins:
2024-02-25T10:15:18Z  QXcbIntegrationPlugin, version 331520
2024-02-25T10:15:18Z Style: fusion / QFusionStyle
2024-02-25T10:15:18Z System: Ubuntu 22.04.4 LTS, x86_64-little_endian-lp64
2024-02-25T10:15:18Z Screen: XWAYLAND0 1920x1080, pixel ratio=1.0
```
- `x86_64-w64-mingw32`
```
2024-02-25T10:44:54Z Qt 5.15.11 (static), plugin=windows (static)
2024-02-25T10:44:54Z Static plugins:
2024-02-25T10:44:54Z  QWindowsVistaStylePlugin, version 331520
2024-02-25T10:44:54Z  QWindowsIntegrationPlugin, version 331520
2024-02-25T10:44:54Z Style: windowsvista / QWindowsVistaStyle
2024-02-25T10:44:54Z System: Windows 11 Version 2009, x86_64-little_endian-llp64
2024-02-25T10:44:54Z Screen: \\.\DISPLAY1 1600x900, pixel ratio=1.0
```

---

2. Apparently, Qt tries to link its default set of static plugins to every suitable target. When building on Windows, it leads to an insane list of plugins:
```
2024-03-01T19:11:04Z Qt 5.15.10 (static), plugin=windows (dynamic)
2024-03-01T19:11:04Z Static plugins:
2024-03-01T19:11:04Z  QGifPlugin, version 331520
2024-03-01T19:11:04Z  QICNSPlugin, version 331520
2024-03-01T19:11:04Z  QICOPlugin, version 331520
2024-03-01T19:11:04Z  QJpegPlugin, version 331520
2024-03-01T19:11:04Z  QSvgIconPlugin, version 331520
2024-03-01T19:11:04Z  QSvgPlugin, version 331520
2024-03-01T19:11:04Z  QTgaPlugin, version 331520
2024-03-01T19:11:04Z  QTiffPlugin, version 331520
2024-03-01T19:11:04Z  QWbmpPlugin, version 331520
2024-03-01T19:11:04Z  QWebpPlugin, version 331520
2024-03-01T19:11:04Z  QWindowsIntegrationPlugin, version 331520
2024-03-01T19:11:04Z  QWindowsVistaStylePlugin, version 331520
```

Therefore, in this PR, we prevent Qt from such a behaviour.