### PR TITLE
cmake, msvc: Allow to build for default `x64-windows` triplet

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -364,8 +364,19 @@ jobs:
 
 
   win64-native-builtin-tools:
-    name: 'Win64 native, VS 2022, built-in tools'
+    name: ${{ matrix.conf.name }}
     runs-on: windows-2022
+
+    strategy:
+      fail-fast: false
+      matrix:
+        conf:
+          - name: 'Win64, VS 2022, dynamic'
+            triplet: 'x64-windows'
+            preset: 'vs2022'
+          - name: 'Win64, VS 2022, static'
+            triplet: 'x64-windows-static'
+            preset: 'vs2022-static'
 
     steps:
       - name: Checkout
@@ -394,17 +405,17 @@ jobs:
           # side-by-side. Therefore, the VCPKG_PLATFORM_TOOLSET_VERSION must be set explicitly
           # to avoid linker errors when using vcpkg in the manifest mode.
           # See: https://github.com/bitcoin/bitcoin/pull/28934
-          Add-Content -Path "$env:VCPKG_ROOT\triplets\x64-windows-static.cmake" -Value "set(VCPKG_PLATFORM_TOOLSET_VERSION $env:VCToolsVersion)"
+          Add-Content -Path "$env:VCPKG_ROOT\triplets\${{ matrix.conf.triplet }}.cmake" -Value "set(VCPKG_PLATFORM_TOOLSET_VERSION $env:VCToolsVersion)"
           # Skip debug configuration to speed up build and minimize cache size.
           Add-Content -Path "$env:VCPKG_ROOT\triplets\x64-windows.cmake" -Value "set(VCPKG_BUILD_TYPE release)"
-          Add-Content -Path "$env:VCPKG_ROOT\triplets\x64-windows-static.cmake" -Value "set(VCPKG_BUILD_TYPE release)"
+          Add-Content -Path "$env:VCPKG_ROOT\triplets\${{ matrix.conf.triplet }}.cmake" -Value "set(VCPKG_BUILD_TYPE release)"
 
       - name: Restore vcpkg binary cache
         uses: actions/cache/restore@v4
         id: vcpkg-binary-cache
         with:
           path: ~/AppData/Local/vcpkg/archives
-          key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-binary-${{ hashFiles('cmake_version', 'msbuild_version', 'toolset_version', 'vcpkg.json') }}
+          key: ${{ matrix.conf.triplet }}-vcpkg-binary-${{ hashFiles('cmake_version', 'msbuild_version', 'toolset_version', 'vcpkg.json') }}
 
       - name: Install Ccache
         run: |
@@ -412,27 +423,31 @@ jobs:
 
       - name: Generate build system
         run: |
-          cmake -B build --preset vs2022
+          cmake -B build --preset ${{ matrix.conf.preset }}
 
       - name: Save vcpkg binary cache
         uses: actions/cache/save@v4
         if: github.event_name != 'pull_request' && steps.vcpkg-binary-cache.outputs.cache-hit != 'true'
         with:
           path: ~/AppData/Local/vcpkg/archives
-          key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-binary-${{ hashFiles('cmake_version', 'msbuild_version', 'toolset_version', 'vcpkg.json') }}
+          key: ${{ matrix.conf.triplet }}-vcpkg-binary-${{ hashFiles('cmake_version', 'msbuild_version', 'toolset_version', 'vcpkg.json') }}
 
       - name: Restore Ccache cache
         id: ccache-cache
         uses: actions/cache/restore@v4
         with:
           path: ~/AppData/Local/ccache
-          key: ${{ github.job }}-ccache-${{ github.run_id }}
-          restore-keys: ${{ github.job }}-ccache-
+          key: ${{ matrix.conf.triplet }}-ccache-${{ github.run_id }}
+          restore-keys: ${{ matrix.conf.triplet }}-ccache-
 
       - name: Build Release configuration
+        working-directory: build
         run: |
           ccache --zero-stats
-          cmake --build build -j $env:NUMBER_OF_PROCESSORS --config Release
+          cmake --build . -j $env:NUMBER_OF_PROCESSORS --config Release
+          dumpbin /imports src\Release\bitcoind.exe | Select-String -Pattern "\.(?i:dll)" | Sort-Object
+          ""
+          (Get-Item src\Release\bitcoind.exe).Length
 
       - name: Ccache stats
         run: |
@@ -444,11 +459,12 @@ jobs:
         if: github.event_name != 'pull_request' && steps.ccache-cache.outputs.cache-hit != 'true'
         with:
           path: ~/AppData/Local/ccache
-          key: ${{ github.job }}-ccache-${{ github.run_id }}
+          key: ${{ matrix.conf.triplet }}-ccache-${{ github.run_id }}
 
       - name: Test Release configuration
+        working-directory: build
         run: |
-          ctest --test-dir build -j $env:NUMBER_OF_PROCESSORS -C Release
+          ctest -j $env:NUMBER_OF_PROCESSORS -C Release
 
       - name: Install Release configuration
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,10 +144,17 @@ if(WIN32)
   )
 
   if(MSVC)
+    if(VCPKG_TARGET_TRIPLET MATCHES "-static")
+      set(msvc_library_linkage "")
+    else()
+      set(msvc_library_linkage "DLL")
+    endif()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>${msvc_library_linkage}")
+    unset(msvc_library_linkage)
+
     target_compile_definitions(core_interface INTERFACE
       _UNICODE;UNICODE
     )
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     target_compile_options(core_interface INTERFACE
       /utf-8
       /Zc:__cplusplus

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,6 +14,22 @@
       "architecture": "x64",
       "toolchainFile": "$env{VCPKG_ROOT}\\scripts\\buildsystems\\vcpkg.cmake",
       "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "x64-windows",
+        "WITH_NATPMP": "OFF"
+      }
+    },
+    {
+      "name": "vs2022-static",
+      "displayName": "Build using 'Visual Studio 17 2022' generator",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "generator": "Visual Studio 17 2022",
+      "architecture": "x64",
+      "toolchainFile": "$env{VCPKG_ROOT}\\scripts\\buildsystems\\vcpkg.cmake",
+      "cacheVariables": {
         "VCPKG_TARGET_TRIPLET": "x64-windows-static",
         "WITH_NATPMP": "OFF"
       }

--- a/cmake/module/AddBoostIfNeeded.cmake
+++ b/cmake/module/AddBoostIfNeeded.cmake
@@ -24,6 +24,12 @@ function(add_boost_if_needed)
     # We don't use multi_index serialization.
     BOOST_MULTI_INDEX_DISABLE_SERIALIZATION
   )
+  if(DEFINED VCPKG_TARGET_TRIPLET)
+    # Workaround for https://github.com/microsoft/vcpkg/issues/36955.
+    target_compile_definitions(Boost::headers INTERFACE
+      BOOST_NO_USER_CONFIG
+    )
+  endif()
 
   if(BUILD_TESTS)
     include(CheckCXXSourceCompiles)

--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -59,7 +59,9 @@
 #include <sys/auxv.h>
 #endif
 
+#ifndef _MSC_VER
 extern char** environ; // NOLINT(readability-redundant-declaration): Necessary on some platforms
+#endif
 
 namespace {
 


### PR DESCRIPTION
The `x64-windows` triplet is the default one when building on Windows. All dependencies are linked dynamically, which is similar to how they are linked on POSIX systems (Linux, macOS) when building without depends.

CI builds both `x64-windows` and `x64-windows-static` triplets. Additionally `dumpbin /imports` output is provided for the `bitcoind.exe` binaries to observe the triplet effect.