### PR TITLE
cmake: Group vcpkg dependencies by features

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,17 +2,46 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "builtin-baseline": "9edb1b8e590cc086563301d735cae4b6e732d2d2",
   "dependencies": [
-    "berkeleydb",
     "boost-date-time",
     "boost-multi-index",
-    "boost-process",
     "boost-signals2",
-    "boost-test",
-    "libevent",
+    "libevent"
+  ],
+  "default-features": [
+    "wallet",
     "miniupnpc",
-    "sqlite3",
-    "qt5-base",
-    "qt5-tools",
-    "zeromq"
-  ]
+    "zeromq",
+    "tests",
+    "qt5"
+  ],
+  "features": {
+    "wallet": {
+      "description": "Enable wallet",
+      "dependencies": [ "berkeleydb", "sqlite3" ]
+    },
+    "sqlite": {
+      "description": "Enable SQLite wallet support",
+      "dependencies": [ "sqlite3" ]
+    },
+    "berkeleydb": {
+      "description": "Enable Berkeley DB wallet support",
+      "dependencies": [ "berkeleydb" ]
+    },
+    "miniupnpc": {
+      "description": "Enable UPnP",
+      "dependencies": [ "miniupnpc" ]
+    },
+    "zeromq": {
+      "description": "Enable ZMQ notifications",
+      "dependencies": [ "zeromq" ]
+    },
+    "tests": {
+      "description": "Build test_bitcoin.exe executable",
+      "dependencies": [ "boost-test" ]
+    },
+    "qt5": {
+      "description": "Build GUI, Qt 5",
+      "dependencies": [ "qt5-base", "qt5-tools" ]
+    }
+  }
 }


### PR DESCRIPTION
The vcpkg package manager build every package from sources. It might be annoying for the user, who is not going to build the GUI, to wait while `qt*` packages are being built.

This PR fixes this. For example, the following invocation:
```
cd build
cmake -S .. --fresh --preset vs2022 -DVCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON -DVCPKG_MANIFEST_FEATURES="wallet;tests"
```
won't build and install `qt*` packages.

---

**Implementation notes**. It seems possible to populate the `VCPKG_MANIFEST_FEATURES` variable on the basis of the actual build option values. However, considering the required integration with our depends, it is not a trivial task and might be considered later.