### PR TITLE
cmake: Improve test naming

### DIFF
--- a/src/test/fuzz/util/CMakeLists.txt
+++ b/src/test/fuzz/util/CMakeLists.txt
@@ -24,8 +24,8 @@ check_cxx_source_links_with_flags("${SANITIZER_LDFLAGS}" "
     #include <cstddef>
     extern \"C\" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) { return 0; }
     // No main() function.
-  " BINARY_LINKS_WITHOUT_MAIN_FUNCTION
+  " FUZZ_BINARY_LINKS_WITHOUT_MAIN_FUNCTION
 )
-if(NOT BINARY_LINKS_WITHOUT_MAIN_FUNCTION)
+if(NOT FUZZ_BINARY_LINKS_WITHOUT_MAIN_FUNCTION)
   target_compile_definitions(test_fuzz PRIVATE PROVIDE_FUZZ_MAIN_FUNCTION)
 endif()


### PR DESCRIPTION
Useful for configuration log readability. Fuzz binary is not to be confused with other binaries.