### PR TITLE
cmake: Build Univalue tests only when `BUILD_TESTS` are enabled

### DIFF
--- a/src/univalue/CMakeLists.txt
+++ b/src/univalue/CMakeLists.txt
@@ -14,20 +14,22 @@ target_include_directories(univalue
 )
 target_link_libraries(univalue PRIVATE core_interface)
 
-add_executable(unitester test/unitester.cpp)
-target_compile_definitions(unitester
-  PRIVATE
-    JSON_TEST_SRC=\"${CMAKE_CURRENT_SOURCE_DIR}/test\"
-)
-target_link_libraries(unitester
-  PRIVATE
-    core_interface
-    univalue
-)
+if(BUILD_TESTS)
+  add_executable(unitester test/unitester.cpp)
+  target_compile_definitions(unitester
+    PRIVATE
+      JSON_TEST_SRC=\"${CMAKE_CURRENT_SOURCE_DIR}/test\"
+  )
+  target_link_libraries(unitester
+    PRIVATE
+      core_interface
+      univalue
+  )
 
-add_executable(object test/object.cpp)
-target_link_libraries(object
-  PRIVATE
-    core_interface
-    univalue
-)
+  add_executable(object test/object.cpp)
+  target_link_libraries(object
+    PRIVATE
+      core_interface
+      univalue
+  )
+endif()


### PR DESCRIPTION
This PR addresses https://github.com/hebasto/bitcoin/pull/89#pullrequestreview-1918281111.