### PR TITLE
cmake: Add `libqrencode` optional package support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ tristate_option(WITH_EXTERNAL_SIGNER
   "if Boost.Process is found."
   AUTO
 )
+tristate_option(WITH_QRENCODE "Enable QR code support." "if libqrencode is found." AUTO)
 
 option(BUILD_TESTS "Build test_bitcoin executable." ON)
 option(BUILD_BENCH "Build bench_bitcoin executable." ON)
@@ -427,6 +428,9 @@ message("  SQLite, descriptor wallets .......... ${WITH_SQLITE}")
 message("  Berkeley DB, legacy wallets ......... ${WITH_BDB}")
 message("Optional packages:")
 message("  GUI ................................. ${WITH_GUI}")
+if(WITH_GUI)
+  message("  QR code (GUI) ....................... ${WITH_QRENCODE}")
+endif()
 message("  external signer ..................... ${WITH_EXTERNAL_SIGNER}")
 message("  NAT-PMP ............................. ${WITH_NATPMP}")
 message("  UPnP ................................ ${WITH_MINIUPNPC}")

--- a/cmake/optional.cmake
+++ b/cmake/optional.cmake
@@ -187,3 +187,23 @@ else()
   set(WITH_SQLITE OFF)
   set(WITH_BDB OFF)
 endif()
+
+if(WITH_GUI AND WITH_QRENCODE)
+  if(MSVC)
+    # TODO: vcpkg fails to build libqrencode package due to
+    #       the build error in its libiconv dependency.
+    #       See: https://github.com/microsoft/vcpkg/issues/36924.
+  else()
+    cross_pkg_check_modules(libqrencode libqrencode IMPORTED_TARGET)
+  endif()
+  if(TARGET PkgConfig::libqrencode)
+    set_target_properties(PkgConfig::libqrencode PROPERTIES
+      INTERFACE_COMPILE_DEFINITIONS USE_QRCODE
+    )
+    set(WITH_QRENCODE ON)
+  elseif(WITH_QRENCODE STREQUAL "AUTO")
+    set(WITH_QRENCODE OFF)
+  else()
+    message(FATAL_ERROR "libqrencode requested, but not found.")
+  endif()
+endif()

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -112,6 +112,7 @@ target_link_libraries(bitcoinqt
     Boost::headers
     $<TARGET_NAME_IF_EXISTS:NATPMP::NATPMP>
     $<TARGET_NAME_IF_EXISTS:MiniUPnPc::MiniUPnPc>
+    $<TARGET_NAME_IF_EXISTS:PkgConfig::libqrencode>
     $<$<PLATFORM_ID:Darwin>:-framework\ AppKit>
     $<$<CXX_COMPILER_ID:MSVC>:shlwapi>
 )


### PR DESCRIPTION
A new configuration option `WITH_QRENCODE` has been added.

This PR, along with https://github.com/hebasto/bitcoin/pull/101, concludes the GUI-specific part of the new CMake-based build system.