### PR TITLE
cmake, ci: Fix "macOS 13 native" job

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -520,6 +520,13 @@ jobs:
           sudo xcode-select --switch ${{ matrix.xcode.path }}
           clang --version
 
+      - name: Workaround for Homebrew python link
+        if: matrix.os.os == 'macos-13'
+        env:
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+        run: |
+          brew install python@3 || brew link --overwrite python@3
+
       - name: Install Homebrew packages
         env:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1


### PR DESCRIPTION
Add workaround for Homebrew's python link error.

Similar to https://github.com/bitcoin/bitcoin/pull/29610.