### PR TITLE
cmake, ci: Ccache improving in macOS jobs

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -552,6 +552,8 @@ jobs:
           ${{ matrix.xcode.configure_env }} cmake -B build -DWERROR=ON
 
       - name: Build
+        env:
+          CCACHE_COMPILERCHECK: '%compiler% -v'
         run: |
           ccache --zero-stats
           cmake --build build -j $(sysctl -n hw.logicalcpu)


### PR DESCRIPTION
For the recent two consequential CI runs:
- https://github.com/hebasto/bitcoin/actions/runs/8263699604 and
- https://github.com/hebasto/bitcoin/actions/runs/8264179478

I've noticed a [pure Ccache performance](https://github.com/hebasto/bitcoin/actions/runs/8264179478/job/22607226576) for the "macOS 13 native, x86_64, Xcode 14.3" job:
```
Cacheable calls:     634 / 634 (100.0%)
  Hits:                0 / 634 ( 0.00%)
```

This PR sets `CCACHE_COMPILERCHECK=%compiler% -v` for macOS jobs to avoid false cache invalidating.

The other option, i.e., `content`, has been tried as well in my experiments, but it also has cache performance issues.