### PR TITLE
[FIXUP] cmake: Do not trigger cross-compiling unnecessarily

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -556,22 +556,20 @@ else()
   )
 endif()
 
-if(CMAKE_CROSSCOMPILING)
-  target_compile_definitions(core_base_interface INTERFACE ${DEPENDS_COMPILE_DEFINITIONS})
-  target_compile_definitions(core_depends_release_interface INTERFACE ${DEPENDS_COMPILE_DEFINITIONS_RELWITHDEBINFO})
-  target_compile_definitions(core_depends_debug_interface INTERFACE ${DEPENDS_COMPILE_DEFINITIONS_DEBUG})
+target_compile_definitions(core_base_interface INTERFACE ${DEPENDS_COMPILE_DEFINITIONS})
+target_compile_definitions(core_depends_release_interface INTERFACE ${DEPENDS_COMPILE_DEFINITIONS_RELWITHDEBINFO})
+target_compile_definitions(core_depends_debug_interface INTERFACE ${DEPENDS_COMPILE_DEFINITIONS_DEBUG})
 
-  # If {C,CXX}FLAGS variables are defined during building depends and
-  # configuring this build system, their content might be duplicated.
-  if(DEFINED ENV{CFLAGS})
-    deduplicate_flags(CMAKE_C_FLAGS)
-  endif()
-  if(DEFINED ENV{CXXFLAGS})
-    deduplicate_flags(CMAKE_CXX_FLAGS)
-  endif()
-  if(DEFINED ENV{LDFLAGS})
-    deduplicate_flags(CMAKE_EXE_LINKER_FLAGS)
-  endif()
+# If {C,CXX,LD}FLAGS variables are defined during building depends and
+# configuring this build system, their content might be duplicated.
+if(DEFINED ENV{CFLAGS})
+  deduplicate_flags(CMAKE_C_FLAGS)
+endif()
+if(DEFINED ENV{CXXFLAGS})
+  deduplicate_flags(CMAKE_CXX_FLAGS)
+endif()
+if(DEFINED ENV{LDFLAGS})
+  deduplicate_flags(CMAKE_EXE_LINKER_FLAGS)
 endif()
 
 add_subdirectory(src)

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -267,7 +267,7 @@ endif
 $(host_prefix)/toolchain.cmake : toolchain.cmake.in $(host_prefix)/.stamp_$(final_build_id)
 	@mkdir -p $(@D)
 	sed -e 's|@depends_crosscompiling@|$(crosscompiling)|' \
-            -e 's|@host_system@|$($(host_os)_cmake_system)|' \
+            -e 's|@host_system_name@|$($(host_os)_cmake_system_name)|' \
             -e 's|@host_arch@|$(host_arch)|' \
             -e 's|@CC@|$(host_CC)|' \
             -e 's|@CXX@|$(host_CXX)|' \

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -268,6 +268,7 @@ $(host_prefix)/toolchain.cmake : toolchain.cmake.in $(host_prefix)/.stamp_$(fina
 	@mkdir -p $(@D)
 	sed -e 's|@depends_crosscompiling@|$(crosscompiling)|' \
             -e 's|@host_system_name@|$($(host_os)_cmake_system_name)|' \
+            -e 's|@host_system_version@|$($(host_os)_cmake_system_version)|' \
             -e 's|@host_arch@|$(host_arch)|' \
             -e 's|@CC@|$(host_CC)|' \
             -e 's|@CXX@|$(host_CXX)|' \

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -258,9 +258,16 @@ $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_
             $< > $@
 	touch $@
 
+ifeq ($(host),$(build))
+  crosscompiling=FALSE
+else
+  crosscompiling=TRUE
+endif
+
 $(host_prefix)/toolchain.cmake : toolchain.cmake.in $(host_prefix)/.stamp_$(final_build_id)
 	@mkdir -p $(@D)
-	sed -e 's|@host_system@|$($(host_os)_cmake_system)|' \
+	sed -e 's|@depends_crosscompiling@|$(crosscompiling)|' \
+            -e 's|@host_system@|$($(host_os)_cmake_system)|' \
             -e 's|@host_arch@|$(host_arch)|' \
             -e 's|@CC@|$(host_CC)|' \
             -e 's|@CXX@|$(host_CXX)|' \

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -187,7 +187,7 @@ ifeq ($($(1)_type),build)
 $(1)_cmake += -DCMAKE_INSTALL_RPATH:PATH="$$($($(1)_type)_prefix)/lib"
 else
 ifneq ($(host),$(build))
-$(1)_cmake += -DCMAKE_SYSTEM_NAME=$($(host_os)_cmake_system)
+$(1)_cmake += -DCMAKE_SYSTEM_NAME=$($(host_os)_cmake_system_name)
 $(1)_cmake += -DCMAKE_C_COMPILER_TARGET=$(host)
 $(1)_cmake += -DCMAKE_CXX_COMPILER_TARGET=$(host)
 endif

--- a/depends/hosts/android.mk
+++ b/depends/hosts/android.mk
@@ -12,4 +12,4 @@ android_CXXFLAGS=-std=$(CXX_STANDARD)
 android_AR=$(ANDROID_TOOLCHAIN_BIN)/llvm-ar
 android_RANLIB=$(ANDROID_TOOLCHAIN_BIN)/llvm-ranlib
 
-android_cmake_system=Android
+android_cmake_system_name=Android

--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -108,4 +108,4 @@ darwin_release_CXXFLAGS=$(darwin_release_CFLAGS)
 darwin_debug_CFLAGS=-O1 -g
 darwin_debug_CXXFLAGS=$(darwin_debug_CFLAGS)
 
-darwin_cmake_system=Darwin
+darwin_cmake_system_name=Darwin

--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -109,3 +109,6 @@ darwin_debug_CFLAGS=-O1 -g
 darwin_debug_CXXFLAGS=$(darwin_debug_CFLAGS)
 
 darwin_cmake_system_name=Darwin
+# Darwin version, which corresponds to OSX_MIN_VERSION.
+# See https://en.wikipedia.org/wiki/Darwin_(operating_system)
+darwin_cmake_system_version=20.1

--- a/depends/hosts/freebsd.mk
+++ b/depends/hosts/freebsd.mk
@@ -28,4 +28,4 @@ x86_64_freebsd_CC=$(default_host_CC) -m64
 x86_64_freebsd_CXX=$(default_host_CXX) -m64
 endif
 
-freebsd_cmake_system=FreeBSD
+freebsd_cmake_system_name=FreeBSD

--- a/depends/hosts/linux.mk
+++ b/depends/hosts/linux.mk
@@ -39,4 +39,4 @@ i686_linux_CXX=$(default_host_CXX) -m32
 x86_64_linux_CC=$(default_host_CC) -m64
 x86_64_linux_CXX=$(default_host_CXX) -m64
 endif
-linux_cmake_system=Linux
+linux_cmake_system_name=Linux

--- a/depends/hosts/linux.mk
+++ b/depends/hosts/linux.mk
@@ -39,4 +39,7 @@ i686_linux_CXX=$(default_host_CXX) -m32
 x86_64_linux_CC=$(default_host_CC) -m64
 x86_64_linux_CXX=$(default_host_CXX) -m64
 endif
+
 linux_cmake_system_name=Linux
+# Refer to doc/dependencies.md for the minimum required kernel.
+linux_cmake_system_version=3.17.0

--- a/depends/hosts/mingw32.mk
+++ b/depends/hosts/mingw32.mk
@@ -20,3 +20,5 @@ mingw32_debug_CXXFLAGS=$(mingw32_debug_CFLAGS)
 mingw32_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC
 
 mingw32_cmake_system_name=Windows
+# Windows 7 (NT 6.1).
+mingw32_cmake_system_version=6.1

--- a/depends/hosts/mingw32.mk
+++ b/depends/hosts/mingw32.mk
@@ -19,4 +19,4 @@ mingw32_debug_CXXFLAGS=$(mingw32_debug_CFLAGS)
 
 mingw32_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC
 
-mingw32_cmake_system=Windows
+mingw32_cmake_system_name=Windows

--- a/depends/hosts/netbsd.mk
+++ b/depends/hosts/netbsd.mk
@@ -36,4 +36,4 @@ x86_64_netbsd_CC=$(default_host_CC) -m64
 x86_64_netbsd_CXX=$(default_host_CXX) -m64
 endif
 
-netbsd_cmake_system=NetBSD
+netbsd_cmake_system_name=NetBSD

--- a/depends/hosts/openbsd.mk
+++ b/depends/hosts/openbsd.mk
@@ -28,4 +28,4 @@ x86_64_openbsd_CC=$(default_host_CC) -m64
 x86_64_openbsd_CXX=$(default_host_CXX) -m64
 endif
 
-openbsd_cmake_system=OpenBSD
+openbsd_cmake_system_name=OpenBSD

--- a/depends/toolchain.cmake.in
+++ b/depends/toolchain.cmake.in
@@ -11,6 +11,7 @@
 # intended.
 if(@depends_crosscompiling@)
   set(CMAKE_SYSTEM_NAME @host_system_name@)
+  set(CMAKE_SYSTEM_VERSION @host_system_version@)
   set(CMAKE_SYSTEM_PROCESSOR @host_arch@)
 endif()
 

--- a/depends/toolchain.cmake.in
+++ b/depends/toolchain.cmake.in
@@ -10,7 +10,7 @@
 # it is best not to touch CMAKE_SYSTEM_NAME unless cross-compiling is
 # intended.
 if(@depends_crosscompiling@)
-  set(CMAKE_SYSTEM_NAME @host_system@)
+  set(CMAKE_SYSTEM_NAME @host_system_name@)
   set(CMAKE_SYSTEM_PROCESSOR @host_arch@)
 endif()
 

--- a/depends/toolchain.cmake.in
+++ b/depends/toolchain.cmake.in
@@ -4,8 +4,15 @@
 
 # This file is expected to be highly volatile and may still change substantially.
 
-set(CMAKE_SYSTEM_NAME @host_system@)
-set(CMAKE_SYSTEM_PROCESSOR @host_arch@)
+# If CMAKE_SYSTEM_NAME is set within a toolchain file, CMake will also
+# set CMAKE_CROSSCOMPILING to TRUE, even if CMAKE_SYSTEM_NAME matches
+# CMAKE_HOST_SYSTEM_NAME. To avoid potential misconfiguration of CMake,
+# it is best not to touch CMAKE_SYSTEM_NAME unless cross-compiling is
+# intended.
+if(@depends_crosscompiling@)
+  set(CMAKE_SYSTEM_NAME @host_system@)
+  set(CMAKE_SYSTEM_PROCESSOR @host_arch@)
+endif()
 
 function(split_compiler_launcher env_compiler launcher compiler)
   set(${launcher})


### PR DESCRIPTION
As it was [pointed](https://github.com/hebasto/bitcoin/pull/82#discussion_r1534141067) out during today's call, the toolchain file, which is generated by the depends build system, unnecessarily triggers CMake's [cross-compiling](https://cmake.org/cmake/help/latest/variable/CMAKE_CROSSCOMPILING.html) mode by setting the [`CMAKE_SYSTEM_NAME`](https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_NAME.html) variable even the host and build systems coincides.

That behavior deviates from the current master branch and potentially might have unwanted/unexpected side effects.

This PR fixes this issue.

All Guix builds remain cross-compiling.