### PR TITLE
cmake: Don't pass `-fno-extended-identifiers` to a linker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,7 +405,7 @@ include(cmake/optional_qt.cmake)
 include(cmake/optional.cmake)
 
 # Don't allow extended (non-ASCII) symbols in identifiers. This is easier for code review.
-try_append_cxx_flags("-fno-extended-identifiers" TARGET core_base_interface)
+try_append_cxx_flags("-fno-extended-identifiers" TARGET core_base_interface SKIP_LINK)
 
 # Currently all versions of gcc are subject to a class of bugs, see the
 # gccbug_90348 test case (only reproduces on GCC 11 and earlier) and


### PR DESCRIPTION
Don't pass `-fno-extended-identifiers` to a linker. Was reported by fanquake offline.