### PR TITLE
cmake [FIXUP]: Add the missing source file

### DIFF
--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -134,11 +134,12 @@ target_link_libraries(fuzz
 if(ENABLE_WALLET)
   target_sources(fuzz
     PRIVATE
-      ${CMAKE_SOURCE_DIR}/src/wallet/test/fuzz/coincontrol.cpp
-      ${CMAKE_SOURCE_DIR}/src/wallet/test/fuzz/coinselection.cpp
-      ${CMAKE_SOURCE_DIR}/src/wallet/test/fuzz/fees.cpp
-      ${CMAKE_SOURCE_DIR}/src/wallet/test/fuzz/parse_iso8601.cpp
-      $<$<BOOL:${USE_SQLITE}>:${CMAKE_SOURCE_DIR}/src/wallet/test/fuzz/notifications.cpp>
+      ${PROJECT_SOURCE_DIR}/src/wallet/test/fuzz/coincontrol.cpp
+      ${PROJECT_SOURCE_DIR}/src/wallet/test/fuzz/coinselection.cpp
+      ${PROJECT_SOURCE_DIR}/src/wallet/test/fuzz/fees.cpp
+      ${PROJECT_SOURCE_DIR}/src/wallet/test/fuzz/parse_iso8601.cpp
+      $<$<BOOL:${USE_SQLITE}>:${PROJECT_SOURCE_DIR}/src/wallet/test/fuzz/notifications.cpp>
+      $<$<BOOL:${USE_SQLITE}>:${PROJECT_SOURCE_DIR}/src/wallet/test/fuzz/scriptpubkeyman.cpp>
   )
   target_link_libraries(fuzz bitcoin_wallet)
 endif()


### PR DESCRIPTION
I've noticed that a source file was missed somewhere in rebase / sync cycles.