### PR TITLE
cmake: Backport changes from the master branch

### DIFF
--- a/cmake/bitcoin-config.h.in
+++ b/cmake/bitcoin-config.h.in
@@ -88,7 +88,10 @@
 /* Define this symbol if you have posix_fallocate */
 #cmakedefine HAVE_POSIX_FALLOCATE 1
 
-/* Define this symbol to build code that uses getauxval) */
+/* Define this symbol if platform supports unix domain sockets */
+#cmakedefine HAVE_SOCKADDR_UN 1
+
+/* Define this symbol to build code that uses getauxval */
 #cmakedefine HAVE_STRONG_GETAUXVAL 1
 
 /* Define this symbol if the BSD sysctl() is available */

--- a/cmake/bitcoin-config.h.in
+++ b/cmake/bitcoin-config.h.in
@@ -73,6 +73,9 @@
    sys/random.h */
 #cmakedefine HAVE_GETENTROPY_RAND 1
 
+/* Define this symbol if the Linux getrandom function call is available */
+#cmakedefine HAVE_GETRANDOM 1
+
 /* Define this symbol if gmtime_r is available */
 #cmakedefine HAVE_GMTIME_R 1
 
@@ -102,9 +105,6 @@
 
 /* Define to 1 if std::system or ::wsystem is available. */
 #cmakedefine HAVE_SYSTEM 1
-
-/* Define this symbol if the Linux getrandom system call is available */
-#cmakedefine HAVE_SYS_GETRANDOM 1
 
 /* Define to 1 if you have the <sys/prctl.h> header file. */
 #cmakedefine HAVE_SYS_PRCTL_H 1

--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -142,6 +142,19 @@ check_cxx_source_compiles("
   " HAVE_STRONG_GETAUXVAL
 )
 
+# Check for UNIX sockets.
+check_cxx_source_compiles("
+  #include <sys/socket.h>
+  #include <sys/un.h>
+
+  int main()
+  {
+    struct sockaddr_un addr;
+    addr.sun_family = AF_UNIX;
+  }
+  " HAVE_SOCKADDR_UN
+)
+
 # Check for different ways of gathering OS randomness:
 # - Linux getrandom()
 check_cxx_source_compiles("

--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -158,19 +158,26 @@ check_cxx_source_compiles("
 # Check for different ways of gathering OS randomness:
 # - Linux getrandom()
 check_cxx_source_compiles("
-  #include <unistd.h>
-  #include <sys/syscall.h>
-  #include <linux/random.h>
+  #include <sys/random.h>
 
   int main()
   {
-    syscall(SYS_getrandom, nullptr, 32, 0);
+    getrandom(nullptr, 32, 0);
   }
-  " HAVE_SYS_GETRANDOM
+  " HAVE_GETRANDOM
 )
 
 # - BSD getentropy()
-check_cxx_symbol_exists(getentropy "unistd.h;sys/random.h" HAVE_GETENTROPY_RAND)
+check_cxx_source_compiles("
+  #include <sys/random.h>
+
+  int main()
+  {
+    getentropy(nullptr, 32);
+  }
+  " HAVE_GETENTROPY_RAND
+)
+
 
 # - BSD sysctl()
 check_cxx_source_compiles("


### PR DESCRIPTION
This PR:
1) Backports changes from https://github.com/bitcoin/bitcoin/pull/27375.
2) Aligns symbol checks with https://github.com/bitcoin/bitcoin/pull/27699.

A possible way to review this PR and the whole symbol check logic is to observe the Autotools vs CMake diff in the `config/bitcoin-config.h`:
```
./autogen.sh
./configure
cmake -B build
diff -u src/config/bitcoin-config.h build/src/config/bitcoin-config.h
```