### PR TITLE
cmake, ci: Disable qt5 feature temporarily

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -458,7 +458,8 @@ jobs:
 
       - name: Generate build system
         run: |
-          cmake -B build --preset ${{ matrix.conf.preset }} -DWERROR=ON
+          # TODO: Re-enable default features, once the liblzma package become available to build again.
+          cmake -B build --preset ${{ matrix.conf.preset }} -DWERROR=ON -DVCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON -DVCPKG_MANIFEST_FEATURES="wallet;miniupnpc;zeromq;tests"
 
       - name: Save vcpkg binary cache
         uses: actions/cache/save@v4


### PR DESCRIPTION
The xz-backdoor affects our vcpkg dependencies. So disabling some of them temporarily to unlock the CI.