### PR TITLE
cmake, msvc: Pin liblzma version

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -458,8 +458,7 @@ jobs:
 
       - name: Generate build system
         run: |
-          # TODO: Re-enable default features, once the liblzma package become available to build again.
-          cmake -B build --preset ${{ matrix.conf.preset }} -DWERROR=ON -DVCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON -DVCPKG_MANIFEST_FEATURES="wallet;miniupnpc;zeromq;tests"
+          cmake -B build --preset ${{ matrix.conf.preset }} -DWERROR=ON
 
       - name: Save vcpkg binary cache
         uses: actions/cache/save@v4

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "builtin-baseline": "9edb1b8e590cc086563301d735cae4b6e732d2d2",
+  "overrides":[
+    {"name": "liblzma", "version": "5.4.1#1"}
+  ],
   "dependencies": [
     "boost-date-time",
     "boost-multi-index",


### PR DESCRIPTION
This is an alternative to https://github.com/hebasto/bitcoin/pull/137, which does not disable GUI for MSVC builds.