### PR TITLE
cmake: Drop `share` subdirectory in depends toolchain file path

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -170,12 +170,12 @@ jobs:
       - name: Generate build system. Expected to FAIL
         if: ${{ matrix.conf.expected == 'fail' }}
         run: |
-          ! cmake -B build --toolchain depends/x86_64-pc-linux-gnu/share/toolchain.cmake ${{ matrix.conf.build_options }}
+          ! cmake -B build --toolchain depends/x86_64-pc-linux-gnu/toolchain.cmake ${{ matrix.conf.build_options }}
 
       - name: Generate build system. Expected to PASS
         if: ${{ matrix.conf.expected == 'pass' }}
         run: |
-          cmake -B build --toolchain depends/x86_64-pc-linux-gnu/share/toolchain.cmake
+          cmake -B build --toolchain depends/x86_64-pc-linux-gnu/toolchain.cmake
 
 
   ubuntu-jammy-native:
@@ -365,7 +365,7 @@ jobs:
 
       - name: Generate build system
         run: |
-          ${{ matrix.host.configure_env }} cmake -B build --toolchain depends/${{ matrix.host.triplet }}/share/toolchain.cmake ${{ matrix.host.configure_options }}
+          ${{ matrix.host.configure_env }} cmake -B build --toolchain depends/${{ matrix.host.triplet }}/toolchain.cmake ${{ matrix.host.configure_options }}
 
       - name: Build
         run: |

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -252,7 +252,7 @@ mkdir -p "$DISTSRC"
     # shellcheck disable=SC2086
     env CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}" LDFLAGS="${HOST_LDFLAGS}" \
     cmake -S . -B build \
-          --toolchain "${BASEPREFIX}/${HOST}/share/toolchain.cmake" \
+          --toolchain "${BASEPREFIX}/${HOST}/toolchain.cmake" \
           -DCCACHE=OFF \
           ${CONFIGFLAGS}
 

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -259,7 +259,7 @@ $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_
             $< > $@
 	touch $@
 
-$(host_prefix)/share/toolchain.cmake : toolchain.cmake.in $(host_prefix)/.stamp_$(final_build_id)
+$(host_prefix)/toolchain.cmake : toolchain.cmake.in $(host_prefix)/.stamp_$(final_build_id)
 	@mkdir -p $(@D)
 	sed -e 's|@host_system@|$($(host_os)_cmake_system)|' \
             -e 's|@host_arch@|$(host_arch)|' \
@@ -318,7 +318,7 @@ check-sources:
 	@$(foreach package,$(all_packages),$(call check_or_remove_sources,$(package));)
 
 $(host_prefix)/share/config.site: check-packages
-$(host_prefix)/share/toolchain.cmake: check-packages
+$(host_prefix)/toolchain.cmake: check-packages
 
 check-packages: check-sources
 
@@ -328,7 +328,7 @@ clean-all: clean
 clean:
 	@rm -rf $(WORK_PATH) $(BASE_CACHE) $(BUILD) *.log
 
-install: check-packages $(host_prefix)/share/config.site $(host_prefix)/share/toolchain.cmake
+install: check-packages $(host_prefix)/share/config.site $(host_prefix)/toolchain.cmake
 
 
 download-one: check-sources $(all_sources)


### PR DESCRIPTION
There are no reasons to keep the `share` subdirectory in the path to the toolchain file generated by the depends build subsystem.

This topic was discussed  during the call on 2024-04-04.

Required for the following build docs update.