### PR TITLE
cmake, ci: Ensure minimum supported g++ version in CI jobs

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -227,7 +227,7 @@ jobs:
 
       - name: Generate build system
         run: |
-          cmake -B build -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DBoost_INCLUDE_DIR="${PWD}/${{ matrix.conf.boost_archive }}" -DENABLE_WALLET=ON -DWITH_EXTERNAL_SIGNER=ON -DWITH_MINIUPNPC=ON -DWITH_NATPMP=ON -DWITH_ZMQ=ON -DWITH_USDT=ON -DWERROR=ON
+          cmake -B build -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DBoost_INCLUDE_DIR="${PWD}/${{ matrix.conf.boost_archive }}" -DENABLE_WALLET=ON -DWITH_EXTERNAL_SIGNER=ON -DWITH_MINIUPNPC=ON -DWITH_NATPMP=ON -DWITH_ZMQ=ON -DWITH_USDT=ON -DWERROR=ON
 
       - name: Build
         working-directory: build
@@ -260,7 +260,8 @@ jobs:
 
   cross-build:
     name: ${{ matrix.host.name }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container: debian:bookworm
 
     strategy:
       fail-fast: false
@@ -295,10 +296,12 @@ jobs:
             skip_install: 'true'
           - name: 'macOS x86_64'
             triplet: 'x86_64-apple-darwin'
+            packages: 'zip'
             macos_sdk: 'Xcode-15.0-15A240d-extracted-SDK-with-libcxx-headers'
             configure_options: '-DWERROR=ON'
           - name: 'macOS arm64'
             triplet: 'arm64-apple-darwin'
+            packages: 'zip'
             macos_sdk: 'Xcode-15.0-15A240d-extracted-SDK-with-libcxx-headers'
             configure_options: '-DWERROR=ON'
 
@@ -308,8 +311,8 @@ jobs:
 
       - name: Install dependency packages
         run: |
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends ccache ${{ matrix.host.packages }}
+          apt-get update
+          apt-get install --no-install-recommends -y autoconf automake binutils bison ca-certificates ccache cmake curl g++ lbzip2 libtool make patch pkg-config python3 tree xz-utils wget ${{ matrix.host.packages }}
           echo "CCACHE_DIR=${{ runner.temp }}/ccache" >> "$GITHUB_ENV"
 
       - name: Depends fingerprint (1)


### PR DESCRIPTION
This PR follows the minimum g++-11 requirements from https://github.com/bitcoin/bitcoin/pull/29091:

1. Update gcc version in the "ubuntu-jammy-native" job.

2. Switch the "cross-build" task to the debian::bookworm image, which effectively bumps `x86_64-w64-mingw32-g++-posix` version to 12.2.

This PR should be merged before the next sync/rebase cycle, which is about to happen.