### PR TITLE
cmake: Backport changes from PR29786

### DIFF
--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -89,7 +89,6 @@ target_link_libraries(bitcoinkernel
     bitcoin_crypto
     leveldb
     secp256k1
-    $<$<PLATFORM_ID:Windows>:ws2_32>
   PUBLIC
     Boost::headers
 )


### PR DESCRIPTION
Linking to `ws2_32` is no longer needed after https://github.com/bitcoin/bitcoin/pull/29786.

How to test:
```
cmake -B build --toolchain depends/x86_64-w64-mingw32/toolchain.cmake -DBUILD_UTIL_CHAINSTATE=ON
cmake --build build -t bitcoin-chainstate
```