### PR TITLE
cmake: Fix white space linter warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 #  - CMake 3.26.5, https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/
 if(POLICY CMP0141)
   # MSVC debug information format flags are selected by an abstraction.
-  # We want to use the CMAKE_MSVC_DEBUG_INFORMATION_FORMAT variable 
+  # We want to use the CMAKE_MSVC_DEBUG_INFORMATION_FORMAT variable
   # to select the MSVC debug information format.
   cmake_policy(SET CMP0141 NEW)
 endif()


### PR DESCRIPTION
Remove trailing space to make the linter happy.