### PR TITLE
cmake: Add missed library for `test_bitcoin`

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -146,6 +146,7 @@ target_link_libraries(test_bitcoin
   bitcoin_node
   minisketch
   Boost::headers
+  libevent::libevent
 )
 
 if(ENABLE_WALLET)


### PR DESCRIPTION
Required in `src/test/raii_event_tests.cpp`.

Otherwise, compiling on illumos (SunOS) fails:
```
/export/home/hebasto/git/bitcoin/src/test/raii_event_tests.cpp:5:10: fatal error: event2/event.h: No such file or directory
    5 | #include <event2/event.h>
      |          ^~~~~~~~~~~~~~~~
compilation terminated.
```

UPD. The same issue happens on macOS Monterey 12.7.4 (Intel).