### PR TITLE
cmake: Add user-defined `EXTRA_{CPP,C,CXX,LD}FLAGS`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,8 @@ target_link_options(extra_flags_interface INTERFACE
   ${EXTRA_LDFLAGS}
 )
 
+include(AddTargetMacros)
+
 if(FUZZ)
   message(WARNING "FUZZ=ON will disable all other targets and force BUILD_FUZZ_BINARY=ON.")
   set(BUILD_DAEMON OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,11 @@ cmake_dependent_option(FUZZ "Build for fuzzing. Enabling this will disable all o
 
 option(INSTALL_MAN "Install man pages." ON)
 
+set(EXTRA_CPPFLAGS "" CACHE STRING "Extra (Objective) C/C++ preprocessor flags.")
+set(EXTRA_CFLAGS "" CACHE STRING "Extra C compiler flags.")
+set(EXTRA_CXXFLAGS "" CACHE STRING "Extra (Objective) C++ compiler flags.")
+set(EXTRA_LDFLAGS "" CACHE STRING "Extra linker flags.")
+
 set(configure_warnings)
 
 include(CheckPIESupported)
@@ -122,6 +127,23 @@ target_link_libraries(core_base_interface INTERFACE
   $<$<CONFIG:Debug>:core_depends_debug_interface>
 )
 target_link_libraries(core_interface INTERFACE core_base_interface)
+
+# The extra_flags_interface library encapsulates user-provided build
+# flags that are appended to the command line after all other flags
+# added by the build system.
+add_library(extra_flags_interface INTERFACE)
+separate_arguments(EXTRA_CPPFLAGS)
+separate_arguments(EXTRA_CFLAGS)
+separate_arguments(EXTRA_CXXFLAGS)
+separate_arguments(EXTRA_LDFLAGS)
+target_compile_options(extra_flags_interface INTERFACE
+  ${EXTRA_CPPFLAGS}
+  $<$<COMPILE_LANGUAGE:C>:${EXTRA_CFLAGS}>
+  $<$<COMPILE_LANGUAGE:CXX>:${EXTRA_CXXFLAGS}>
+)
+target_link_options(extra_flags_interface INTERFACE
+  ${EXTRA_LDFLAGS}
+)
 
 if(FUZZ)
   message(WARNING "FUZZ=ON will disable all other targets and force BUILD_FUZZ_BINARY=ON.")

--- a/cmake/crc32c.cmake
+++ b/cmake/crc32c.cmake
@@ -78,7 +78,7 @@ check_cxx_source_compiles_with_flags("${ARM_CRC_CXXFLAGS}" "
   " HAVE_ARM64_CRC32C
 )
 
-add_library(crc32c STATIC EXCLUDE_FROM_ALL
+subtree_add_library(crc32c STATIC EXCLUDE_FROM_ALL
   ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c.cc
   ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c_portable.cc
 )
@@ -111,5 +111,3 @@ if(HAVE_ARM64_CRC32C)
     APPEND PROPERTY COMPILE_OPTIONS ${ARM_CRC_CXXFLAGS}
   )
 endif()
-
-target_link_libraries(crc32c PRIVATE core_base_interface)

--- a/cmake/leveldb.cmake
+++ b/cmake/leveldb.cmake
@@ -9,7 +9,7 @@
 include(CheckCXXSymbolExists)
 check_cxx_symbol_exists(F_FULLFSYNC "fcntl.h" HAVE_FULLFSYNC)
 
-add_library(leveldb STATIC EXCLUDE_FROM_ALL
+subtree_add_library(leveldb STATIC EXCLUDE_FROM_ALL
   ${PROJECT_SOURCE_DIR}/src/leveldb/db/builder.cc
   ${PROJECT_SOURCE_DIR}/src/leveldb/db/c.cc
   ${PROJECT_SOURCE_DIR}/src/leveldb/db/db_impl.cc
@@ -95,7 +95,6 @@ else()
 endif()
 
 target_link_libraries(leveldb PRIVATE
-  core_base_interface
   nowarn_leveldb_interface
   crc32c
 )

--- a/cmake/minisketch.cmake
+++ b/cmake/minisketch.cmake
@@ -40,7 +40,7 @@ if(MSVC)
 endif()
 
 if(HAVE_CLMUL)
-  add_library(minisketch_clmul OBJECT EXCLUDE_FROM_ALL
+  subtree_add_library(minisketch_clmul OBJECT EXCLUDE_FROM_ALL
     ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_1byte.cpp
     ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_2bytes.cpp
     ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/clmul_3bytes.cpp
@@ -54,12 +54,11 @@ if(HAVE_CLMUL)
   target_compile_options(minisketch_clmul PRIVATE ${CLMUL_CXXFLAGS})
   target_link_libraries(minisketch_clmul
     PRIVATE
-      core_base_interface
       minisketch_common
   )
 endif()
 
-add_library(minisketch STATIC EXCLUDE_FROM_ALL
+subtree_add_library(minisketch STATIC EXCLUDE_FROM_ALL
   ${PROJECT_SOURCE_DIR}/src/minisketch/src/minisketch.cpp
   ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/generic_1byte.cpp
   ${PROJECT_SOURCE_DIR}/src/minisketch/src/fields/generic_2bytes.cpp
@@ -78,7 +77,6 @@ target_include_directories(minisketch
 
 target_link_libraries(minisketch
   PRIVATE
-    core_base_interface
     minisketch_common
     $<TARGET_NAME_IF_EXISTS:minisketch_clmul>
 )

--- a/cmake/module/AddTargetMacros.cmake
+++ b/cmake/module/AddTargetMacros.cmake
@@ -15,3 +15,15 @@ function(bitcoincore_add_library name)
     )
   ")
 endfunction()
+
+function(bitcoincore_add_executable name)
+  cmake_parse_arguments(PARSE_ARGV 1 FWD "" "" "")
+  add_executable("${name}" ${FWD_UNPARSED_ARGUMENTS})
+  target_link_libraries("${name}" PRIVATE core_interface)
+  cmake_language(EVAL CODE "
+    cmake_language(DEFER
+      DIRECTORY ${PROJECT_SOURCE_DIR}
+      CALL target_link_libraries ${name} PRIVATE extra_flags_interface
+    )
+  ")
+endfunction()

--- a/cmake/module/AddTargetMacros.cmake
+++ b/cmake/module/AddTargetMacros.cmake
@@ -4,6 +4,18 @@
 
 include_guard(GLOBAL)
 
+function(subtree_add_library name)
+  cmake_parse_arguments(PARSE_ARGV 1 FWD "" "" "")
+  add_library("${name}" ${FWD_UNPARSED_ARGUMENTS})
+  target_link_libraries("${name}" PRIVATE core_base_interface)
+  cmake_language(EVAL CODE "
+    cmake_language(DEFER
+      DIRECTORY ${PROJECT_SOURCE_DIR}
+      CALL target_link_libraries ${name} PRIVATE extra_flags_interface
+    )
+  ")
+endfunction()
+
 function(bitcoincore_add_library name)
   cmake_parse_arguments(PARSE_ARGV 1 FWD "" "" "")
   add_library("${name}" ${FWD_UNPARSED_ARGUMENTS})

--- a/cmake/module/AddTargetMacros.cmake
+++ b/cmake/module/AddTargetMacros.cmake
@@ -4,7 +4,14 @@
 
 include_guard(GLOBAL)
 
+# Functions in this module are drop-in replacements for CMake's add_library
+# and add_executable functions. They are mandatory for use in the Bitcoin
+# Core project, except for imported and interface libraries.
+
 function(subtree_add_library name)
+  if(NOT name MATCHES "^crc32c.*|^leveldb.*|^minisketch.*|^secp256k1.*")
+    message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION}() was called to add a non-subtree target \"${name}\".")
+  endif()
   cmake_parse_arguments(PARSE_ARGV 1 FWD "" "" "")
   add_library("${name}" ${FWD_UNPARSED_ARGUMENTS})
   target_link_libraries("${name}" PRIVATE core_base_interface)
@@ -17,6 +24,9 @@ function(subtree_add_library name)
 endfunction()
 
 function(bitcoincore_add_library name)
+  if(name MATCHES "^crc32c.*|^leveldb.*|^minisketch.*|^secp256k1.*")
+    message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION}() was called to add a subtree target \"${name}\".")
+  endif()
   cmake_parse_arguments(PARSE_ARGV 1 FWD "" "" "")
   add_library("${name}" ${FWD_UNPARSED_ARGUMENTS})
   target_link_libraries("${name}" PRIVATE core_interface)

--- a/cmake/module/AddTargetMacros.cmake
+++ b/cmake/module/AddTargetMacros.cmake
@@ -1,0 +1,17 @@
+# Copyright (c) 2024-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+
+include_guard(GLOBAL)
+
+function(bitcoincore_add_library name)
+  cmake_parse_arguments(PARSE_ARGV 1 FWD "" "" "")
+  add_library("${name}" ${FWD_UNPARSED_ARGUMENTS})
+  target_link_libraries("${name}" PRIVATE core_interface)
+  cmake_language(EVAL CODE "
+    cmake_language(DEFER
+      DIRECTORY ${PROJECT_SOURCE_DIR}
+      CALL target_link_libraries ${name} PRIVATE extra_flags_interface
+    )
+  ")
+endfunction()

--- a/cmake/secp256k1.cmake
+++ b/cmake/secp256k1.cmake
@@ -22,7 +22,7 @@ check_c_source_compiles("
   " HAVE_64BIT_ASM
 )
 
-add_library(secp256k1 STATIC EXCLUDE_FROM_ALL
+subtree_add_library(secp256k1 STATIC EXCLUDE_FROM_ALL
   ${PROJECT_SOURCE_DIR}/src/secp256k1/src/secp256k1.c
   ${PROJECT_SOURCE_DIR}/src/secp256k1/src/precomputed_ecmult.c
   ${PROJECT_SOURCE_DIR}/src/secp256k1/src/precomputed_ecmult_gen.c
@@ -54,5 +54,3 @@ if(MSVC)
       /wd4267
   )
 endif()
-
-target_link_libraries(secp256k1 PRIVATE core_base_interface)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,16 +19,12 @@ add_custom_target(generate_build_info
   COMMENT "Generating obj/build.h"
   VERBATIM
 )
-add_library(bitcoin_clientversion OBJECT EXCLUDE_FROM_ALL
+bitcoincore_add_library(bitcoin_clientversion OBJECT EXCLUDE_FROM_ALL
   clientversion.cpp
 )
 target_compile_definitions(bitcoin_clientversion
   PRIVATE
     HAVE_BUILD_INFO
-)
-target_link_libraries(bitcoin_clientversion
-  PRIVATE
-    core_interface
 )
 add_dependencies(bitcoin_clientversion generate_build_info)
 
@@ -41,7 +37,7 @@ endif()
 
 
 # Stable, backwards-compatible consensus functionality.
-add_library(bitcoin_consensus STATIC EXCLUDE_FROM_ALL
+bitcoincore_add_library(bitcoin_consensus STATIC EXCLUDE_FROM_ALL
   arith_uint256.cpp
   consensus/merkle.cpp
   consensus/tx_check.cpp
@@ -57,18 +53,17 @@ add_library(bitcoin_consensus STATIC EXCLUDE_FROM_ALL
 )
 target_link_libraries(bitcoin_consensus
   PRIVATE
-    core_interface
     bitcoin_crypto
     secp256k1
 )
 
 if(WITH_ZMQ)
-  add_subdirectory(zmq EXCLUDE_FROM_ALL)
+  add_subdirectory(zmq)
 endif()
 
 # Home for common functionality shared by different executables and libraries.
 # Similar to `bitcoin_util` library, but higher-level.
-add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
+bitcoincore_add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
   addresstype.cpp
   base58.cpp
   bech32.cpp
@@ -116,7 +111,6 @@ add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
 )
 target_link_libraries(bitcoin_common
   PRIVATE
-    core_interface
     bitcoin_consensus
     bitcoin_util
     univalue
@@ -150,7 +144,7 @@ endif()
 
 
 # P2P and RPC server functionality used by `bitcoind` and `bitcoin-qt` executables.
-add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
+bitcoincore_add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   addrdb.cpp
   addrman.cpp
   banman.cpp
@@ -246,7 +240,6 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
 )
 target_link_libraries(bitcoin_node
   PRIVATE
-    core_interface
     bitcoin_common
     bitcoin_util
     leveldb
@@ -290,13 +283,12 @@ if(MULTIPROCESS)
 endif()
 
 
-add_library(bitcoin_cli STATIC EXCLUDE_FROM_ALL
+bitcoincore_add_library(bitcoin_cli STATIC EXCLUDE_FROM_ALL
   compat/stdin.cpp
   rpc/client.cpp
 )
 target_link_libraries(bitcoin_cli
   PUBLIC
-    core_interface
     univalue
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,8 +40,8 @@ if(MULTIPROCESS)
 endif()
 
 
-add_library(bitcoin_consensus_sources INTERFACE)
-target_sources(bitcoin_consensus_sources INTERFACE
+# Stable, backwards-compatible consensus functionality.
+add_library(bitcoin_consensus STATIC EXCLUDE_FROM_ALL
   arith_uint256.cpp
   consensus/merkle.cpp
   consensus/tx_check.cpp
@@ -55,14 +55,9 @@ target_sources(bitcoin_consensus_sources INTERFACE
   uint256.cpp
   util/strencodings.cpp
 )
-
-# Stable, backwards-compatible consensus functionality
-# also exposed as a shared library or a static one.
-add_library(bitcoin_consensus STATIC EXCLUDE_FROM_ALL)
 target_link_libraries(bitcoin_consensus
   PRIVATE
     core_interface
-    bitcoin_consensus_sources
     bitcoin_crypto
     secp256k1
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,18 +125,18 @@ if(ENABLE_WALLET)
   add_subdirectory(wallet)
 
   if(BUILD_WALLET_TOOL)
-    add_executable(bitcoin-wallet
+    bitcoincore_add_executable(bitcoin-wallet
       bitcoin-wallet.cpp
       init/bitcoin-wallet.cpp
       wallet/wallettool.cpp
     )
     add_windows_resources(bitcoin-wallet bitcoin-wallet-res.rc)
     target_link_libraries(bitcoin-wallet
-      core_interface
-      bitcoin_wallet
-      bitcoin_common
-      bitcoin_util
-      Boost::headers
+      PRIVATE
+        bitcoin_wallet
+        bitcoin_common
+        bitcoin_util
+        Boost::headers
     )
     list(APPEND installable_targets bitcoin-wallet)
   endif()
@@ -256,28 +256,28 @@ target_link_libraries(bitcoin_node
 
 # Bitcoin Core bitcoind.
 if(BUILD_DAEMON)
-  add_executable(bitcoind
+  bitcoincore_add_executable(bitcoind
     bitcoind.cpp
     init/bitcoind.cpp
   )
   add_windows_resources(bitcoind bitcoind-res.rc)
   target_link_libraries(bitcoind
-    core_interface
-    bitcoin_node
-    $<TARGET_NAME_IF_EXISTS:bitcoin_wallet>
+    PRIVATE
+      bitcoin_node
+      $<TARGET_NAME_IF_EXISTS:bitcoin_wallet>
   )
   list(APPEND installable_targets bitcoind)
 endif()
 if(MULTIPROCESS)
-  add_executable(bitcoin-node
+  bitcoincore_add_executable(bitcoin-node
     bitcoind.cpp
     init/bitcoin-node.cpp
   )
   target_link_libraries(bitcoin-node
-    core_interface
-    bitcoin_node
-    bitcoin_ipc
-    $<TARGET_NAME_IF_EXISTS:bitcoin_wallet>
+    PRIVATE
+      bitcoin_node
+      bitcoin_ipc
+      $<TARGET_NAME_IF_EXISTS:bitcoin_wallet>
   )
   list(APPEND installable_targets bitcoin-node)
 endif()
@@ -295,39 +295,39 @@ target_link_libraries(bitcoin_cli
 
 # Bitcoin Core RPC client
 if(BUILD_CLI)
-  add_executable(bitcoin-cli bitcoin-cli.cpp)
+  bitcoincore_add_executable(bitcoin-cli bitcoin-cli.cpp)
   add_windows_resources(bitcoin-cli bitcoin-cli-res.rc)
   target_link_libraries(bitcoin-cli
-    core_interface
-    bitcoin_cli
-    bitcoin_common
-    bitcoin_util
-    libevent::libevent
+    PRIVATE
+      bitcoin_cli
+      bitcoin_common
+      bitcoin_util
+      libevent::libevent
   )
   list(APPEND installable_targets bitcoin-cli)
 endif()
 
 
 if(BUILD_TX)
-  add_executable(bitcoin-tx bitcoin-tx.cpp)
+  bitcoincore_add_executable(bitcoin-tx bitcoin-tx.cpp)
   add_windows_resources(bitcoin-tx bitcoin-tx-res.rc)
   target_link_libraries(bitcoin-tx
-    core_interface
-    bitcoin_common
-    bitcoin_util
-    univalue
+    PRIVATE
+      bitcoin_common
+      bitcoin_util
+      univalue
   )
   list(APPEND installable_targets bitcoin-tx)
 endif()
 
 
 if(BUILD_UTIL)
-  add_executable(bitcoin-util bitcoin-util.cpp)
+  bitcoincore_add_executable(bitcoin-util bitcoin-util.cpp)
   add_windows_resources(bitcoin-util bitcoin-util-res.rc)
   target_link_libraries(bitcoin-util
-    core_interface
-    bitcoin_common
-    bitcoin_util
+    PRIVATE
+      bitcoin_common
+      bitcoin_util
   )
   list(APPEND installable_targets bitcoin-util)
 endif()
@@ -343,14 +343,8 @@ if(BUILD_KERNEL_LIB)
 endif()
 
 if(BUILD_UTIL_CHAINSTATE)
-  add_executable(bitcoin-chainstate
-    bitcoin-chainstate.cpp
-  )
-  target_link_libraries(bitcoin-chainstate
-    PRIVATE
-      core_interface
-      bitcoinkernel
-  )
+  bitcoincore_add_executable(bitcoin-chainstate bitcoin-chainstate.cpp)
+  target_link_libraries(bitcoin-chainstate PRIVATE bitcoinkernel)
 endif()
 
 

--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -5,7 +5,7 @@
 include(GenerateHeaders)
 generate_header_from_raw(data/block413567.raw)
 
-add_executable(bench_bitcoin
+bitcoincore_add_executable(bench_bitcoin
   bench_bitcoin.cpp
   bench.cpp
   data.cpp
@@ -53,10 +53,10 @@ add_executable(bench_bitcoin
 )
 
 target_link_libraries(bench_bitcoin
-  core_interface
-  test_util
-  bitcoin_node
-  Boost::headers
+  PRIVATE
+    test_util
+    bitcoin_node
+    Boost::headers
 )
 
 if(ENABLE_WALLET)
@@ -69,7 +69,7 @@ if(ENABLE_WALLET)
       wallet_loading.cpp
       wallet_ismine.cpp
   )
-  target_link_libraries(bench_bitcoin bitcoin_wallet)
+  target_link_libraries(bench_bitcoin PRIVATE bitcoin_wallet)
 endif()
 
 install(TARGETS bench_bitcoin

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -63,7 +63,7 @@ if(NOT MSVC)
   )
 endif()
 
-add_library(bitcoin_crypto STATIC EXCLUDE_FROM_ALL
+bitcoincore_add_library(bitcoin_crypto STATIC EXCLUDE_FROM_ALL
   aes.cpp
   chacha20.cpp
   chacha20poly1305.cpp
@@ -79,11 +79,6 @@ add_library(bitcoin_crypto STATIC EXCLUDE_FROM_ALL
   sha3.cpp
   sha512.cpp
   siphash.cpp
-)
-
-target_link_libraries(bitcoin_crypto
-  PRIVATE
-    core_interface
 )
 
 if(HAVE_SSE41)

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
-add_library(bitcoin_ipc STATIC EXCLUDE_FROM_ALL
+bitcoincore_add_library(bitcoin_ipc STATIC EXCLUDE_FROM_ALL
   capnp/protocol.cpp
   interfaces.cpp
   process.cpp
@@ -10,9 +10,4 @@ add_library(bitcoin_ipc STATIC EXCLUDE_FROM_ALL
 
 target_capnp_sources(bitcoin_ipc ${CMAKE_SOURCE_DIR}
   capnp/echo.capnp capnp/init.capnp
-)
-
-target_link_libraries(bitcoin_ipc
-  PRIVATE
-    core_interface
 )

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -6,7 +6,7 @@
 #       library, as more and more modules are decoupled from the
 #       consensus engine, this list will shrink to only those
 #       which are absolutely necessary.
-add_library(bitcoinkernel EXCLUDE_FROM_ALL
+bitcoincore_add_library(bitcoinkernel EXCLUDE_FROM_ALL
   bitcoinkernel.cpp
   chain.cpp
   checks.cpp
@@ -84,7 +84,6 @@ add_library(bitcoinkernel EXCLUDE_FROM_ALL
 )
 target_link_libraries(bitcoinkernel
   PRIVATE
-    core_interface
     bitcoin_clientversion
     bitcoin_crypto
     leveldb

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -78,7 +78,7 @@ qt5_add_translation(qm_files ${ts_files})
 
 configure_file(bitcoin_locale.qrc bitcoin_locale.qrc COPYONLY)
 
-add_library(bitcoinqt STATIC EXCLUDE_FROM_ALL
+bitcoincore_add_library(bitcoinqt STATIC EXCLUDE_FROM_ALL
   bantablemodel.cpp
   bitcoin.cpp
   bitcoinaddressvalidator.cpp
@@ -128,7 +128,6 @@ target_link_libraries(bitcoinqt
   PUBLIC
     Qt5::Widgets
   PRIVATE
-    core_interface
     bitcoin_cli
     leveldb
     Boost::headers

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -187,7 +187,7 @@ if(QT_IS_STATIC)
   )
 endif()
 
-add_executable(bitcoin-qt
+bitcoincore_add_executable(bitcoin-qt WIN32
   main.cpp
   ../init/bitcoin-qt.cpp
 )
@@ -195,33 +195,27 @@ add_executable(bitcoin-qt
 add_windows_resources(bitcoin-qt res/bitcoin-qt-res.rc)
 
 target_link_libraries(bitcoin-qt
-  core_interface
-  bitcoinqt
-  bitcoin_node
+  PRIVATE
+    bitcoinqt
+    bitcoin_node
 )
 
 import_plugins(bitcoin-qt)
 set(installable_targets bitcoin-qt)
-if(WIN32)
-  set_target_properties(bitcoin-qt PROPERTIES WIN32_EXECUTABLE TRUE)
-endif()
 
 if(MULTIPROCESS)
-  add_executable(bitcoin-gui
+  bitcoincore_add_executable(bitcoin-gui WIN32
     main.cpp
     ../init/bitcoin-gui.cpp
   )
   target_link_libraries(bitcoin-gui
-    core_interface
-    bitcoinqt
-    bitcoin_node
-    bitcoin_ipc
+    PRIVATE
+      bitcoinqt
+      bitcoin_node
+      bitcoin_ipc
   )
   import_plugins(bitcoin-gui)
   list(APPEND installable_targets bitcoin-gui)
-  if(WIN32)
-    set_target_properties(bitcoin-gui PROPERTIES WIN32_EXECUTABLE TRUE)
-  endif()
 endif()
 
 install(TARGETS ${installable_targets}

--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
-add_executable(test_bitcoin-qt
+bitcoincore_add_executable(test_bitcoin-qt
   apptests.cpp
   optiontests.cpp
   rpcnestedtests.cpp
@@ -13,12 +13,12 @@ add_executable(test_bitcoin-qt
 )
 
 target_link_libraries(test_bitcoin-qt
-  core_interface
-  bitcoinqt
-  test_util
-  bitcoin_node
-  Boost::headers
-  Qt5::Test
+  PRIVATE
+    bitcoinqt
+    test_util
+    bitcoin_node
+    Boost::headers
+    Qt5::Test
 )
 
 import_plugins(test_bitcoin-qt)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -14,7 +14,7 @@ generate_header_from_json(data/tx_invalid.json)
 generate_header_from_json(data/tx_valid.json)
 generate_header_from_raw(data/asmap.raw)
 
-add_executable(test_bitcoin
+bitcoincore_add_executable(test_bitcoin
   main.cpp
   $<TARGET_OBJECTS:bitcoin_consensus>
   ${CMAKE_CURRENT_BINARY_DIR}/data/asmap.raw.h
@@ -140,13 +140,13 @@ add_executable(test_bitcoin
 )
 
 target_link_libraries(test_bitcoin
-  core_interface
-  test_util
-  bitcoin_cli
-  bitcoin_node
-  minisketch
-  Boost::headers
-  libevent::libevent
+  PRIVATE
+    test_util
+    bitcoin_cli
+    bitcoin_node
+    minisketch
+    Boost::headers
+    libevent::libevent
 )
 
 if(ENABLE_WALLET)
@@ -170,10 +170,10 @@ if(ENABLE_WALLET)
       ../wallet/test/walletdb_tests.cpp
       ../wallet/test/walletload_tests.cpp
   )
-  target_link_libraries(test_bitcoin bitcoin_wallet)
   if(USE_BDB)
     target_sources(test_bitcoin PRIVATE ../wallet/test/db_tests.cpp)
   endif()
+  target_link_libraries(test_bitcoin PRIVATE bitcoin_wallet)
 endif()
 
 if(MULTIPROCESS)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -177,20 +177,16 @@ if(ENABLE_WALLET)
 endif()
 
 if(MULTIPROCESS)
-  add_library(bitcoin_ipc_test STATIC EXCLUDE_FROM_ALL
+  bitcoincore_add_library(bitcoin_ipc_test STATIC EXCLUDE_FROM_ALL
     ipc_test.cpp
   )
-
   target_capnp_sources(bitcoin_ipc_test ${CMAKE_SOURCE_DIR}
     ipc_test.capnp
   )
-
   target_link_libraries(bitcoin_ipc_test
     PRIVATE
-      core_interface
       univalue
   )
-
   target_sources(test_bitcoin
     PRIVATE
       ipc_tests.cpp

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 add_subdirectory(util)
 
-add_executable(fuzz
+bitcoincore_add_executable(fuzz
   addition_overflow.cpp
   addrman.cpp
   asmap.cpp
@@ -121,16 +121,16 @@ add_executable(fuzz
   versionbits.cpp
 )
 target_link_libraries(fuzz
-  core_interface
-  test_fuzz
-  bitcoin_cli
-  bitcoin_common
-  minisketch
-  leveldb
-  univalue
-  secp256k1
-  Boost::headers
-  libevent::libevent
+  PRIVATE
+    test_fuzz
+    bitcoin_cli
+    bitcoin_common
+    minisketch
+    leveldb
+    univalue
+    secp256k1
+    Boost::headers
+    libevent::libevent
 )
 
 if(ENABLE_WALLET)
@@ -143,5 +143,5 @@ if(ENABLE_WALLET)
       $<$<BOOL:${USE_SQLITE}>:${PROJECT_SOURCE_DIR}/src/wallet/test/fuzz/notifications.cpp>
       $<$<BOOL:${USE_SQLITE}>:${PROJECT_SOURCE_DIR}/src/wallet/test/fuzz/scriptpubkeyman.cpp>
   )
-  target_link_libraries(fuzz bitcoin_wallet)
+  target_link_libraries(fuzz PRIVATE bitcoin_wallet)
 endif()

--- a/src/test/fuzz/util/CMakeLists.txt
+++ b/src/test/fuzz/util/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
-add_library(test_fuzz STATIC EXCLUDE_FROM_ALL
+bitcoincore_add_library(test_fuzz STATIC EXCLUDE_FROM_ALL
   descriptor.cpp
   mempool.cpp
   net.cpp
@@ -12,7 +12,6 @@ add_library(test_fuzz STATIC EXCLUDE_FROM_ALL
 
 target_link_libraries(test_fuzz
   PRIVATE
-    core_interface
     test_util
     bitcoin_node
     Boost::headers

--- a/src/test/util/CMakeLists.txt
+++ b/src/test/util/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
-add_library(test_util STATIC EXCLUDE_FROM_ALL
+bitcoincore_add_library(test_util STATIC EXCLUDE_FROM_ALL
   blockfilter.cpp
   coins.cpp
   index.cpp
@@ -22,7 +22,6 @@ add_library(test_util STATIC EXCLUDE_FROM_ALL
 
 target_link_libraries(test_util
   PRIVATE
-    core_interface
     Boost::headers
   PUBLIC
     univalue

--- a/src/univalue/CMakeLists.txt
+++ b/src/univalue/CMakeLists.txt
@@ -14,21 +14,13 @@ target_include_directories(univalue
 )
 
 if(BUILD_TESTS)
-  add_executable(unitester test/unitester.cpp)
+  bitcoincore_add_executable(unitester test/unitester.cpp)
   target_compile_definitions(unitester
     PRIVATE
       JSON_TEST_SRC=\"${CMAKE_CURRENT_SOURCE_DIR}/test\"
   )
-  target_link_libraries(unitester
-    PRIVATE
-      core_interface
-      univalue
-  )
+  target_link_libraries(unitester PRIVATE univalue)
 
-  add_executable(object test/object.cpp)
-  target_link_libraries(object
-    PRIVATE
-      core_interface
-      univalue
-  )
+  bitcoincore_add_executable(object test/object.cpp)
+  target_link_libraries(object PRIVATE univalue)
 endif()

--- a/src/univalue/CMakeLists.txt
+++ b/src/univalue/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
-add_library(univalue STATIC EXCLUDE_FROM_ALL
+bitcoincore_add_library(univalue STATIC EXCLUDE_FROM_ALL
   lib/univalue.cpp
   lib/univalue_get.cpp
   lib/univalue_read.cpp
@@ -12,7 +12,6 @@ target_include_directories(univalue
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
-target_link_libraries(univalue PRIVATE core_interface)
 
 if(BUILD_TESTS)
   add_executable(unitester test/unitester.cpp)

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
-add_library(bitcoin_util STATIC EXCLUDE_FROM_ALL
+bitcoincore_add_library(bitcoin_util STATIC EXCLUDE_FROM_ALL
   asmap.cpp
   batchpriority.cpp
   bip32.cpp
@@ -44,7 +44,6 @@ add_library(bitcoin_util STATIC EXCLUDE_FROM_ALL
 
 target_link_libraries(bitcoin_util
   PRIVATE
-    core_interface
     bitcoin_clientversion
     bitcoin_crypto
     Threads::Threads

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -3,7 +3,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 # Wallet functionality used by bitcoind and bitcoin-wallet executables.
-add_library(bitcoin_wallet STATIC EXCLUDE_FROM_ALL
+bitcoincore_add_library(bitcoin_wallet STATIC EXCLUDE_FROM_ALL
   coincontrol.cpp
   coinselection.cpp
   context.cpp
@@ -34,7 +34,6 @@ add_library(bitcoin_wallet STATIC EXCLUDE_FROM_ALL
 )
 target_link_libraries(bitcoin_wallet
   PRIVATE
-    core_interface
     bitcoin_common
     univalue
     Boost::headers

--- a/src/zmq/CMakeLists.txt
+++ b/src/zmq/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
-add_library(bitcoin_zmq STATIC
+bitcoincore_add_library(bitcoin_zmq STATIC EXCLUDE_FROM_ALL
   zmqabstractnotifier.cpp
   zmqnotificationinterface.cpp
   zmqpublishnotifier.cpp
@@ -15,7 +15,6 @@ target_compile_definitions(bitcoin_zmq
 )
 target_link_libraries(bitcoin_zmq
   PRIVATE
-    core_interface
     univalue
     $<TARGET_NAME_IF_EXISTS:libzmq>
     $<TARGET_NAME_IF_EXISTS:PkgConfig::libzmq>


### PR DESCRIPTION
This PR implements the CMake WG design decision made during the call on 2024-04-18.

```
$ cmake -B build -LH 2>&1 | grep -B 1 -e EXTRA_
// Extra C compiler flags.
EXTRA_CFLAGS:STRING=
--
// Extra (Objective) C/C++ preprocessor flags.
EXTRA_CPPFLAGS:STRING=
--
// Extra (Objective) C++ compiler flags.
EXTRA_CXXFLAGS:STRING=
--
// Extra linker flags.
EXTRA_LDFLAGS:STRING=
```

To test this PR, I suggest to observe raw build logs using the `--verbose` command-line option.

The related https://github.com/hebasto/bitcoin/pull/93 is to be reworked on top of this PR.