### PR TITLE
cmake: Add `docs` build target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -543,6 +543,7 @@ endif()
 
 add_subdirectory(src)
 add_subdirectory(test)
+add_subdirectory(doc)
 
 include(cmake/tests.cmake)
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright (c) 2024-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+
+find_package(Doxygen COMPONENTS dot)
+
+if(DOXYGEN_FOUND)
+  set(doxyfile ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+  configure_file(Doxyfile.in ${doxyfile})
+
+  # In CMake 3.27, The FindDoxygen module's doxygen_add_docs()
+  # command gained a CONFIG_FILE option to specify a custom doxygen
+  # configuration file.
+  # TODO: Consider using it.
+  add_custom_target(docs
+    COMMAND Doxygen::doxygen ${doxyfile}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    COMMENT "Generating developer documentation"
+    VERBATIM USES_TERMINAL
+  )
+else()
+  add_custom_target(docs
+    COMMAND ${CMAKE_COMMAND} -E echo "Error: Doxygen not found"
+  )
+endif()

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -58,7 +58,7 @@ PROJECT_LOGO           = doc/bitcoin_logo_doxygen.png
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = doc/doxygen
+OUTPUT_DIRECTORY       = @PROJECT_BINARY_DIR@/doc/doxygen
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -339,11 +339,11 @@ Recommendations:
 
 ### Generating Documentation
 
-The documentation can be generated with `make docs` and cleaned up with `make
-clean-docs`. The resulting files are located in `doc/doxygen/html`; open
+The documentation can be generated with `cmake --build <build_dir> --target docs`.
+The resulting files are located in `<build_dir>/doc/doxygen/html`; open
 `index.html` in that directory to view the homepage.
 
-Before running `make docs`, you'll need to install these dependencies:
+Before building the `docs` target, you'll need to install these dependencies:
 
 Linux: `sudo apt install doxygen graphviz`
 


### PR DESCRIPTION
Same as `make docs` in the master branch.