### PR TITLE
cmake: Switch from tri-state options to boolean. Stage FOUR

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -555,7 +555,7 @@ jobs:
         env:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |
-          brew install ccache cmake pkg-config boost libevent berkeley-db@4 qt@5 libnatpmp miniupnpc zeromq tree
+          brew install ccache cmake pkg-config boost libevent berkeley-db@4 qt@5 qrencode libnatpmp miniupnpc zeromq tree
           echo "CCACHE_DIR=${{ runner.temp }}/ccache" >> "$GITHUB_ENV"
 
       - name: CMake version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,16 @@ tristate_option(WITH_USDT
 )
 cmake_dependent_option(WITH_EXTERNAL_SIGNER "Enable external signer support." ON "NOT WIN32" OFF)
 set(ENABLE_EXTERNAL_SIGNER ${WITH_EXTERNAL_SIGNER})
-tristate_option(WITH_QRENCODE "Enable QR code support." "if libqrencode is found." AUTO)
+
+include(cmake/optional_qt.cmake)
+cmake_dependent_option(WITH_QRENCODE "Enable QR code support." ON "WITH_GUI" OFF)
+if(WITH_QRENCODE)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(libqrencode REQUIRED IMPORTED_TARGET libqrencode)
+  target_compile_definitions(PkgConfig::libqrencode INTERFACE
+    USE_QRCODE
+  )
+endif()
 
 option(MULTIPROCESS "Build multiprocess bitcoin-node, bitcoin-wallet, and bitcoin-gui executables in addition to monolithic bitcoind and bitcoin-qt executables. Requires libmultiprocess library. Experimental." OFF)
 if(MULTIPROCESS)
@@ -439,8 +448,6 @@ else()
   unset(compiler_supports_g3)
   unset(c_flags_debug_overridden)
 endif()
-
-include(cmake/optional_qt.cmake)
 
 include(cmake/optional.cmake)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -57,6 +57,8 @@
       "toolchainFile": "$env{VCPKG_ROOT}\\scripts\\buildsystems\\vcpkg.cmake",
       "cacheVariables": {
         "VCPKG_TARGET_TRIPLET": "x64-windows",
+        "WITH_GUI": "Qt5",
+        "WITH_QRENCODE": "OFF",
         "WITH_NATPMP": "OFF"
       }
     },
@@ -73,6 +75,8 @@
       "toolchainFile": "$env{VCPKG_ROOT}\\scripts\\buildsystems\\vcpkg.cmake",
       "cacheVariables": {
         "VCPKG_TARGET_TRIPLET": "x64-windows-static",
+        "WITH_GUI": "Qt5",
+        "WITH_QRENCODE": "OFF",
         "WITH_NATPMP": "OFF"
       }
     }

--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -181,7 +181,3 @@ check_cxx_source_compiles("
   int main(){}
   " HAVE_DLLEXPORT_ATTRIBUTE
 )
-
-if(CMAKE_HOST_APPLE)
-  find_program(BREW_COMMAND brew)
-endif()

--- a/cmake/module/FindBerkeleyDB.cmake
+++ b/cmake/module/FindBerkeleyDB.cmake
@@ -27,17 +27,21 @@ This module defines the following variables:
 
 #]=======================================================================]
 
-if(BREW_COMMAND)
-  # The Homebrew package manager installs the berkeley-db* packages as
-  # "keg-only", which means they are not symlinked into the default prefix.
-  # To find such a package, the find_path() and find_library() commands
-  # need additional path hints that are computed by Homebrew itself.
-  execute_process(
-    COMMAND ${BREW_COMMAND} --prefix berkeley-db@4
-    OUTPUT_VARIABLE _BerkeleyDB_homebrew_prefix
-    ERROR_QUIET
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
+set(_BerkeleyDB_homebrew_prefix)
+if(CMAKE_HOST_APPLE)
+  find_program(HOMEBREW_EXECUTABLE brew)
+  if(HOMEBREW_EXECUTABLE)
+    # The Homebrew package manager installs the berkeley-db* packages as
+    # "keg-only", which means they are not symlinked into the default prefix.
+    # To find such a package, the find_path() and find_library() commands
+    # need additional path hints that are computed by Homebrew itself.
+    execute_process(
+      COMMAND ${HOMEBREW_EXECUTABLE} --prefix berkeley-db@4
+      OUTPUT_VARIABLE _BerkeleyDB_homebrew_prefix
+      ERROR_QUIET
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  endif()
 endif()
 
 find_path(BerkeleyDB_INCLUDE_DIR

--- a/cmake/optional.cmake
+++ b/cmake/optional.cmake
@@ -133,24 +133,3 @@ else()
   set(WITH_SQLITE OFF)
   set(WITH_BDB OFF)
 endif()
-
-if(WITH_GUI AND WITH_QRENCODE)
-  if(VCPKG_TARGET_TRIPLET)
-    # TODO: vcpkg fails to build libqrencode package due to
-    #       the build error in its libiconv dependency.
-    #       See: https://github.com/microsoft/vcpkg/issues/36924.
-  else()
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(libqrencode IMPORTED_TARGET libqrencode)
-  endif()
-  if(TARGET PkgConfig::libqrencode)
-    set_target_properties(PkgConfig::libqrencode PROPERTIES
-      INTERFACE_COMPILE_DEFINITIONS USE_QRCODE
-    )
-    set(WITH_QRENCODE ON)
-  elseif(WITH_QRENCODE STREQUAL "AUTO")
-    set(WITH_QRENCODE OFF)
-  else()
-    message(FATAL_ERROR "libqrencode requested, but not found.")
-  endif()
-endif()

--- a/cmake/optional_qt.cmake
+++ b/cmake/optional_qt.cmake
@@ -12,13 +12,17 @@ if(WITH_GUI)
   set(QT_NO_CREATE_VERSIONLESS_FUNCTIONS ON)
   set(QT_NO_CREATE_VERSIONLESS_TARGETS ON)
 
-  if(BREW_COMMAND)
-    execute_process(
-      COMMAND ${BREW_COMMAND} --prefix qt@5
-      OUTPUT_VARIABLE qt5_brew_prefix
-      ERROR_QUIET
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
+  set(qt5_brew_prefix)
+  if(CMAKE_HOST_APPLE)
+    find_program(HOMEBREW_EXECUTABLE brew)
+    if(HOMEBREW_EXECUTABLE)
+      execute_process(
+        COMMAND ${HOMEBREW_EXECUTABLE} --prefix qt@5
+        OUTPUT_VARIABLE qt5_brew_prefix
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+    endif()
   endif()
 
   if(WITH_GUI STREQUAL "AUTO")


### PR DESCRIPTION
This PR is a continuation of https://github.com/hebasto/bitcoin/pull/161, https://github.com/hebasto/bitcoin/pull/162 and https://github.com/hebasto/bitcoin/pull/164 and tackles with the `WITH_QRENCODE`  options.

It becomes enabled when building GUI with the default value `ON`.