### PR TITLE
cmake: Amend `bitcoin_crypto` static library

### DIFF
--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -87,45 +87,41 @@ target_link_libraries(bitcoin_crypto
 )
 
 if(HAVE_SSE41)
-  target_sources(bitcoin_crypto PRIVATE sha256_sse41.cpp)
-  set_property(SOURCE sha256_sse41.cpp
-    APPEND PROPERTY COMPILE_OPTIONS ${SSE41_CXXFLAGS}
+  add_library(bitcoin_crypto_sse41 STATIC EXCLUDE_FROM_ALL
+    sha256_sse41.cpp
   )
-  target_compile_definitions(bitcoin_crypto
-    PRIVATE
-      ENABLE_SSE41
-  )
+  target_compile_definitions(bitcoin_crypto_sse41 PUBLIC ENABLE_SSE41)
+  target_compile_options(bitcoin_crypto_sse41 PRIVATE ${SSE41_CXXFLAGS})
+  target_link_libraries(bitcoin_crypto_sse41 PRIVATE core_interface)
+  target_link_libraries(bitcoin_crypto PRIVATE bitcoin_crypto_sse41)
 endif()
 
 if(HAVE_AVX2)
-  target_sources(bitcoin_crypto PRIVATE sha256_avx2.cpp)
-  set_property(SOURCE sha256_avx2.cpp
-    APPEND PROPERTY COMPILE_OPTIONS ${AVX2_CXXFLAGS}
+  add_library(bitcoin_crypto_avx2 STATIC EXCLUDE_FROM_ALL
+    sha256_avx2.cpp
   )
-  target_compile_definitions(bitcoin_crypto
-    PRIVATE
-      ENABLE_AVX2
-  )
+  target_compile_definitions(bitcoin_crypto_avx2 PUBLIC ENABLE_AVX2)
+  target_compile_options(bitcoin_crypto_avx2 PRIVATE ${AVX2_CXXFLAGS})
+  target_link_libraries(bitcoin_crypto_avx2 PRIVATE core_interface)
+  target_link_libraries(bitcoin_crypto PRIVATE bitcoin_crypto_avx2)
 endif()
 
 if(HAVE_X86_SHANI)
-  target_sources(bitcoin_crypto PRIVATE sha256_x86_shani.cpp)
-  set_property(SOURCE sha256_x86_shani.cpp
-    APPEND PROPERTY COMPILE_OPTIONS ${X86_SHANI_CXXFLAGS}
+  add_library(bitcoin_crypto_x86_shani STATIC EXCLUDE_FROM_ALL
+    sha256_x86_shani.cpp
   )
-  target_compile_definitions(bitcoin_crypto
-    PRIVATE
-      ENABLE_X86_SHANI
-  )
+  target_compile_definitions(bitcoin_crypto_x86_shani PUBLIC ENABLE_X86_SHANI)
+  target_compile_options(bitcoin_crypto_x86_shani PRIVATE ${X86_SHANI_CXXFLAGS})
+  target_link_libraries(bitcoin_crypto_x86_shani PRIVATE core_interface)
+  target_link_libraries(bitcoin_crypto PRIVATE bitcoin_crypto_x86_shani)
 endif()
 
 if(HAVE_ARM_SHANI)
-  target_sources(bitcoin_crypto PRIVATE sha256_arm_shani.cpp)
-  set_property(SOURCE sha256_arm_shani.cpp
-    APPEND PROPERTY COMPILE_OPTIONS ${ARM_SHANI_CXXFLAGS}
+  add_library(bitcoin_crypto_arm_shani STATIC EXCLUDE_FROM_ALL
+    sha256_arm_shani.cpp
   )
-  target_compile_definitions(bitcoin_crypto
-    PRIVATE
-      ENABLE_ARM_SHANI
-  )
+  target_compile_definitions(bitcoin_crypto_arm_shani PUBLIC ENABLE_ARM_SHANI)
+  target_compile_options(bitcoin_crypto_arm_shani PRIVATE ${ARM_SHANI_CXXFLAGS})
+  target_link_libraries(bitcoin_crypto_arm_shani PRIVATE core_interface)
+  target_link_libraries(bitcoin_crypto PRIVATE bitcoin_crypto_arm_shani)
 endif()


### PR DESCRIPTION
Avoid using source-specific compile options. They hard to reason about and error-prone when combining with target-specific compile options.

The resulted build logic effectively mirrors the master branch's one.

Required for https://github.com/hebasto/bitcoin/pull/157.

Similar to https://github.com/hebasto/bitcoin/pull/171.