### PR TITLE
cmake, lint: Adjust `lint_includes_build_config`

### DIFF
--- a/cmake/bitcoin-config.h.in
+++ b/cmake/bitcoin-config.h.in
@@ -1,9 +1,8 @@
-// Copyright (c) 2023 The Bitcoin Core developers
+// Copyright (c) 2023-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://opensource.org/license/mit/.
 
 #ifndef BITCOIN_CONFIG_H
-
 #define BITCOIN_CONFIG_H
 
 /* Version Build */

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -2,8 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <config/bitcoin-config.h> // IWYU pragma: keep
-
 #include <crypto/sha256.h>
 #include <crypto/common.h>
 

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -2,8 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <config/bitcoin-config.h> // IWYU pragma: keep
-
 #include <httpserver.h>
 
 #include <chainparamsbase.h>

--- a/src/qt/qrimagewidget.cpp
+++ b/src/qt/qrimagewidget.cpp
@@ -15,8 +15,6 @@
 #include <QMouseEvent>
 #include <QPainter>
 
-#include <config/bitcoin-config.h> // IWYU pragma: keep
-
 #ifdef USE_QRCODE
 #include <qrencode.h>
 #endif

--- a/src/qt/receiverequestdialog.cpp
+++ b/src/qt/receiverequestdialog.cpp
@@ -14,8 +14,6 @@
 #include <QDialog>
 #include <QString>
 
-#include <config/bitcoin-config.h> // IWYU pragma: keep
-
 ReceiveRequestDialog::ReceiveRequestDialog(QWidget* parent)
     : QDialog(parent, GUIUtil::dialog_flags),
       ui(new Ui::ReceiveRequestDialog)

--- a/src/test/util_threadnames_tests.cpp
+++ b/src/test/util_threadnames_tests.cpp
@@ -11,8 +11,6 @@
 #include <thread>
 #include <vector>
 
-#include <config/bitcoin-config.h> // IWYU pragma: keep
-
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(util_threadnames_tests)

--- a/test/lint/test_runner/src/main.rs
+++ b/test/lint/test_runner/src/main.rs
@@ -177,20 +177,14 @@ Please add any false positives, such as subtrees, or externally sourced files to
 }
 
 fn lint_includes_build_config() -> LintResult {
-    let config_path = "./src/config/bitcoin-config.h.in";
-    if !Path::new(config_path).is_file() {
-        assert!(Command::new("./autogen.sh")
-            .status()
-            .expect("command error")
-            .success());
-    }
+    let config_path = "./cmake/bitcoin-config.h.in";
     let defines_regex = format!(
         r"^\s*(?!//).*({})",
-        check_output(Command::new("grep").args(["undef ", "--", config_path]))
+        check_output(Command::new("grep").args(["define", "--", config_path]))
             .expect("grep failed")
             .lines()
             .map(|line| {
-                line.split("undef ")
+                line.split_whitespace()
                     .nth(1)
                     .unwrap_or_else(|| panic!("Could not extract name in line: {line}"))
             })


### PR DESCRIPTION
The linter has been adjusted to consider CMake-specific `bitcoin-config.h.in` file.

Linter warnings have been fixed.

Can be tested by running linters [locally](https://github.com/bitcoin/bitcoin/tree/master/test/lint#running-locally).