### PR TITLE
cmake: Fix and improve CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -489,9 +489,6 @@ jobs:
         run: |
           ccache --zero-stats
           cmake --build . -j $env:NUMBER_OF_PROCESSORS --config Release
-          dumpbin /imports src\Release\bitcoind.exe | Select-String -Pattern "\.(?i:dll)" | Sort-Object
-          ""
-          (Get-Item src\Release\bitcoind.exe).Length
 
       - name: Ccache stats
         run: |
@@ -504,6 +501,13 @@ jobs:
         with:
           path: ~/AppData/Local/ccache
           key: ${{ matrix.conf.triplet }}-ccache-${{ github.run_id }}
+
+      - name: Inspect build artifacts
+        working-directory: build
+        run: |
+          dumpbin /imports src\Release\bitcoind.exe | Select-String -Pattern "\.(?i:dll)" | Sort-Object
+          ""
+          (Get-Item src\Release\bitcoind.exe).Length
 
       - name: Test Release configuration
         working-directory: build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -358,11 +358,8 @@ jobs:
 
       - name: Build depends
         working-directory: depends
-        env:
-          CC: ${{ matrix.host.c_compiler }}
-          CXX: ${{ matrix.host.cxx_compiler }}
         run: |
-          make -j$(nproc) HOST=${{ matrix.host.triplet }} ${{ matrix.host.depends_options }} LOG=1
+          make -j$(nproc) HOST=${{ matrix.host.triplet }} CC="${{ matrix.host.c_compiler }}" CXX="${{ matrix.host.cxx_compiler }}" ${{ matrix.host.depends_options }} LOG=1
 
       - name: Restore Ccache cache
         uses: actions/cache/restore@v4


### PR DESCRIPTION
1. The first commit forces the build step in the native Windows jobs to fail if build fails. Otherwise, the build step might
falsely succeed because the last command exit code determines the return status of the step.

I've noticed such wrong behaviour while working on https://github.com/hebasto/bitcoin/pull/182.

2. The second commit pulled from https://github.com/hebasto/bitcoin/pull/125.