### PR TITLE
cmake: Enable additional security checks for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,7 @@ if(WIN32)
     target_compile_options(core_interface INTERFACE
       /utf-8
       /Zc:__cplusplus
+      /sdl
     )
     # Improve parallelism in MSBuild.
     # See: https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/.

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -12,6 +12,7 @@
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <validation.h>
 
 #include <vector>
@@ -102,14 +103,14 @@ BOOST_FIXTURE_TEST_CASE(chainstate_update_tip, TestChain100Setup)
 
     BOOST_CHECK_EQUAL(chainman.GetAll().size(), 2);
 
-    Chainstate& background_cs{*[&] {
+    Chainstate& background_cs{*Assert([&]() -> Chainstate* {
         for (Chainstate* cs : chainman.GetAll()) {
             if (cs != &chainman.ActiveChainstate()) {
                 return cs;
             }
         }
-        assert(false);
-    }()};
+        return nullptr;
+    }())};
 
     // Append the first block to the background chain.
     BlockValidationState state;


### PR DESCRIPTION
Same as on the master branch: https://github.com/hebasto/bitcoin/blob/99d7538cdb2a0ab7a7a2116cd5f33b95fc52b00e/build_msvc/common.init.vcxproj.in#L64

The first commit has been pulled from https://github.com/bitcoin/bitcoin/pull/30026.