### PR TITLE
cmake, doc: Modernize cmake invocations

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -103,32 +103,26 @@ There are many ways to configure Bitcoin Core, here are a few common examples:
 ##### Descriptor Wallet and GUI:
 This explicitly enables the GUI and disables legacy wallet support, assuming `sqlite` and `qt` are installed.
 ```bash
-mkdir build
-cd build
-cmake -S .. -DWITH_BDB=OFF -DWITH_GUI=Qt5
+cmake -B build -DWITH_BDB=OFF -DWITH_GUI=Qt5
 ```
 
-Run `cmake .. -LH` to see the full list of available options. 
+Run `cmake -B build -LH` to see the full list of available options.
 
 ##### Descriptor & Legacy Wallet. No GUI:
 This enables support for both wallet types and disables the GUI, assuming
 `sqlite3` and `db4` are both installed.
 ```bash
-mkdir build
-cd build
-cmake -S .. -DWITH_GUI=OFF -DBerkeleyDB_INCLUDE_DIR:PATH="${BDB_PREFIX}/include"
+cmake -B build -DWITH_GUI=OFF -DBerkeleyDB_INCLUDE_DIR:PATH="${BDB_PREFIX}/include"
 ```
 
 ##### No Wallet or GUI
 ```bash
-mkdir build
-cd build
-cmake -S .. -DENABLE_WALLET=OFF -DWITH_GUI=OFF
+cmake -B build -DENABLE_WALLET=OFF -DWITH_GUI=OFF
 ```
 
 ### 2. Compile
 
 ```bash
-cmake --build . # Use "-j N" for N parallel jobs.
-ctest # Run tests if Python 3 is available. Use "-j N" for N parallel tests.
+cmake --build build     # Use "-j N" for N parallel jobs.
+ctest --test-dir build  # Use "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
 ```

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -193,9 +193,7 @@ If `sqlite` is installed, then descriptor wallet support will also be built.
 Additionally, this explicitly disables the GUI.
 
 ``` bash
-mkdir build
-cd build
-cmake -S .. -DWITH_GUI=OFF
+cmake -B build -DWITH_GUI=OFF
 ```
 
 ##### Wallet (only SQlite) and GUI Support:
@@ -206,17 +204,13 @@ If `sqlite` is installed then descriptor wallet functionality will be built.
 If `sqlite` is not installed, then wallet functionality will be disabled.
 
 ``` bash
-mkdir build
-cd build
-cmake -S .. -DWITH_BDB=OFF -DWITH_GUI=Qt5
+cmake -B build -DWITH_BDB=OFF -DWITH_GUI=Qt5
 ```
 
 ##### No Wallet or GUI
 
 ``` bash
-mkdir build
-cd build
-cmake -S .. -DENABLE_WALLET=OFF -DWITH_GUI=OFF
+cmake -B build -DENABLE_WALLET=OFF -DWITH_GUI=OFF
 ```
 
 ##### Further Configuration
@@ -225,7 +219,7 @@ You may want to dig deeper into the configuration options to achieve your desire
 Examine the output of the following command for a full list of configuration options:
 
 ``` bash
-cmake -S .. -LH
+cmake -B build -LH
 ```
 
 ### 2. Compile
@@ -234,8 +228,8 @@ After configuration, you are ready to compile.
 Run the following in your terminal to compile Bitcoin Core:
 
 ``` bash
-cmake --build .  # Use "-j N" here for N parallel jobs.
-ctest            # Run tests if Python 3 is available. Use "-j N" here for N parallel jobs.
+cmake --build build     # Use "-j N" here for N parallel jobs.
+ctest --test-dir build  # Use "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
 ```
 
 ### 3. Deploy (optional)
@@ -243,7 +237,7 @@ ctest            # Run tests if Python 3 is available. Use "-j N" here for N par
 You can also create a  `.zip` containing the `.app` bundle by running the following command:
 
 ``` bash
-cmake --build . --target deploy
+cmake --build build --target deploy
 ```
 
 ## Running Bitcoin Core
@@ -279,8 +273,8 @@ tail -f $HOME/Library/Application\ Support/Bitcoin/debug.log
 ## Other commands:
 
 ```shell
-./src/bitcoind -daemon      # Starts the bitcoin daemon.
-./src/bitcoin-cli --help    # Outputs a list of command-line options.
-./src/bitcoin-cli help      # Outputs a list of RPC commands when the daemon is running.
-./src/qt/bitcoin-qt -server # Starts the bitcoin-qt server mode, allows bitcoin-cli control
+./build/src/bitcoind -daemon      # Starts the bitcoin daemon.
+./build/src/bitcoin-cli --help    # Outputs a list of command-line options.
+./build/src/bitcoin-cli help      # Outputs a list of RPC commands when the daemon is running.
+./build/src/qt/bitcoin-qt -server # Starts the bitcoin-qt server mode, allows bitcoin-cli control
 ```

--- a/doc/build-windows-msvc.md
+++ b/doc/build-windows-msvc.md
@@ -45,29 +45,24 @@ cmake --list-presets
 ## Building
 
 CMake will put the resulting object files, libraries, and executables into a dedicated build directory.
-This guide assumes that all commands are executed in build directory created like that:
-```
-mkdir build
-cd build
-```
 
 In following istructions, the "Debug" configuration can be specified instead of the "Release" one.
 
 ### 4. Building with Dynamic Linking
 
 ```
-cmake -S .. --preset vs2022  # It might take a while if the vcpkg binary cache is unpopulated or invalidated
-cmake --build . --config Release
-ctest --build-config Release
+cmake -B build --preset vs2022                 # It might take a while if the vcpkg binary cache is unpopulated or invalidated.
+cmake --build build --config Release           # Use "-j N" for N parallel jobs.
+ctest --test-dir build --build-config Release  # Use "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
 ```
 
 ### 5. Building with Static Linking
 
 ```
-cmake -S .. --preset vs2022-static  # It might take a while if the vcpkg binary cache is unpopulated or invalidated
-cmake --build . --config Release
-ctest --build-config Release
-cmake --install . --config Release  # Optional
+cmake -B build --preset vs2022-static          # It might take a while if the vcpkg binary cache is unpopulated or invalidated.
+cmake --build build --config Release           # Use "-j N" for N parallel jobs.
+ctest --test-dir build --build-config Release  # Use "-j N" for N parallel tests. Some tests are disabled if Python 3 is not available.
+cmake --install build --config Release         # Optional.
 ```
 
 ## Performance Notes
@@ -77,7 +72,7 @@ cmake --install . --config Release  # Optional
 One can skip vcpkg manifest default features to speedup the configuration step.
 For example, the following invocation will skip all features except for "wallet" and "tests" and their dependencies:
 ```
-cmake -S .. --preset vs2022 -DVCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON -DVCPKG_MANIFEST_FEATURES="wallet;tests"
+cmake -B build --preset vs2022 -DVCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON -DVCPKG_MANIFEST_FEATURES="wallet;tests"
 ```
 
 Available features are listed in the [`vcpkg.json`](/vcpkg.json) file.


### PR DESCRIPTION
This PR amends build docs according the discussion in https://github.com/hebasto/bitcoin/pull/167 where there were agreed to use modern cmake invocations.

Simplifies https://github.com/hebasto/bitcoin/pull/173 and https://github.com/hebasto/bitcoin/pull/177.