### PR TITLE
cmake: Drop default `-O0` for `DEBUG` configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,8 +449,6 @@ else()
     endif()
     unset(compiler_supports_ftrapv)
 
-    string(PREPEND CMAKE_CXX_FLAGS_DEBUG "-O0 ")
-
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}"
       CACHE STRING
       "Flags used by the CXX compiler during DEBUG builds."
@@ -465,8 +463,6 @@ else()
     if(compiler_supports_g3)
       replace_c_flag_in_config(Debug -g -g3)
     endif()
-
-    string(PREPEND CMAKE_C_FLAGS_DEBUG "-O0 ")
 
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}"
       CACHE STRING


### PR DESCRIPTION
There is no need to specify `-O0`, which is the compilier's default, for the `DEBUG` build configuration.

It was needed in Autotools to override their default `-O2`.