### PR TITLE
cmake: Mark `Qt5*_DIR` cache variables as advanced 

### DIFF
--- a/cmake/module/FindQt5.cmake
+++ b/cmake/module/FindQt5.cmake
@@ -60,3 +60,7 @@ find_package_handle_standard_args(Qt5
   REQUIRED_VARS Qt5_DIR
   VERSION_VAR Qt5_VERSION
 )
+
+foreach(component IN LISTS Qt5_FIND_COMPONENTS ITEMS "")
+  mark_as_advanced(Qt5${component}_DIR)
+endforeach()


### PR DESCRIPTION
Mark `Qt5*_DIR` cache variables as advanced to hide them in the GUI and avoid clutter.

See https://github.com/hebasto/bitcoin/issues/194.