### PR TITLE
cmake, vcpkg: Pin `libevent` version

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "builtin-baseline": "9edb1b8e590cc086563301d735cae4b6e732d2d2",
   "overrides":[
+    {"name": "libevent", "version": "2.1.12#7"},
     {"name": "liblzma", "version": "5.4.1#1"}
   ],
   "dependencies": [


### PR DESCRIPTION
For more details, see https://github.com/bitcoin/bitcoin/issues/30096.