### PR TITLE
cmake: Port PR29494 from the master branch

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,6 @@ include(GNUInstallDirs)
 include(AddWindowsResources)
 
 configure_file(${CMAKE_SOURCE_DIR}/cmake/bitcoin-config.h.in config/bitcoin-config.h @ONLY)
-add_compile_definitions(HAVE_CONFIG_H)
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
 # After the transition from Autotools to CMake, the obj/ subdirectory


### PR DESCRIPTION
This PR ports https://github.com/bitcoin/bitcoin/pull/29494 after the recent sync/rebase [PR](https://github.com/hebasto/bitcoin/pull/202).