### PR TITLE
cmake: Disable `EXPORT_COMPILE_COMMANDS` for all subtree targets

### DIFF
--- a/cmake/crc32c.cmake
+++ b/cmake/crc32c.cmake
@@ -96,6 +96,7 @@ target_include_directories(crc32c
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/crc32c/include>
 )
 target_link_libraries(crc32c PRIVATE crc32c_common)
+set_target_properties(crc32c PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
 
 if(HAVE_SSE42)
   add_library(crc32c_sse42 STATIC EXCLUDE_FROM_ALL
@@ -104,6 +105,7 @@ if(HAVE_SSE42)
   target_compile_definitions(crc32c_sse42 PUBLIC HAVE_SSE42=1)
   target_compile_options(crc32c_sse42 PRIVATE ${SSE42_CXXFLAGS})
   target_link_libraries(crc32c_sse42 PRIVATE crc32c_common)
+  set_target_properties(crc32c_sse42 PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
   target_link_libraries(crc32c PRIVATE crc32c_sse42)
 endif()
 
@@ -114,5 +116,6 @@ if(HAVE_ARM64_CRC32C)
   target_compile_definitions(crc32c_arm64 PUBLIC HAVE_ARM64_CRC32C=1)
   target_compile_options(crc32c_arm64 PRIVATE ${ARM64_CRC_CXXFLAGS})
   target_link_libraries(crc32c_arm64 PRIVATE crc32c_common)
+  set_target_properties(crc32c_arm64 PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
   target_link_libraries(crc32c PRIVATE crc32c_arm64)
 endif()

--- a/cmake/secp256k1.cmake
+++ b/cmake/secp256k1.cmake
@@ -57,3 +57,4 @@ if(MSVC)
 endif()
 
 target_link_libraries(secp256k1 PRIVATE core_base_interface)
+set_target_properties(secp256k1 PROPERTIES EXPORT_COMPILE_COMMANDS OFF)


### PR DESCRIPTION
Fixes the second point from https://github.com/bitcoin/bitcoin/pull/29790#issuecomment-2121349899:
>    2. Missed disabling `EXPORT_COMPILE_COMMANDS` property for targets in the `crc32c` subtree.