### PR TITLE
cmake, ci: Skip `miniupnpc` package in depends

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -359,7 +359,7 @@ jobs:
       - name: Build depends
         working-directory: depends
         run: |
-          make -j$(nproc) HOST=${{ matrix.host.triplet }} CC="${{ matrix.host.c_compiler }}" CXX="${{ matrix.host.cxx_compiler }}" ${{ matrix.host.depends_options }} LOG=1
+          make -j$(nproc) HOST=${{ matrix.host.triplet }} CC="${{ matrix.host.c_compiler }}" CXX="${{ matrix.host.cxx_compiler }}" ${{ matrix.host.depends_options }} LOG=1 NO_UPNP=1
 
       - name: Restore Ccache cache
         uses: actions/cache/restore@v4


### PR DESCRIPTION
This change fixes CI jobs as the `miniupnpc` source archive is not available neither at https://miniupnp.tuxfamily.org nor at https://bitcoincore.org/depends-sources at this moment.

It could be reverted back after https://github.com/bitcoin/bitcoin/pull/30151 or uploading  the source archive to the https://bitcoincore.org.