### PR TITLE
cmake: Port PR30137 from the master branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,6 @@ if(WITH_BDB)
 endif()
 cmake_dependent_option(BUILD_WALLET_TOOL "Build bitcoin-wallet tool." ${BUILD_TESTS} "ENABLE_WALLET" OFF)
 
-option(ENABLE_THREADLOCAL "Enable features that depend on the C++ thread_local keyword (currently just thread names in debug logs)." ON)
 option(ENABLE_HARDENING "Attempt to harden the resulting executables." ON)
 option(REDUCE_EXPORTS "Attempt to reduce exported symbols in the resulting executables." OFF)
 option(WERROR "Treat compiler warnings as errors." OFF)

--- a/cmake/module/AddThreadsIfNeeded.cmake
+++ b/cmake/module/AddThreadsIfNeeded.cmake
@@ -18,25 +18,5 @@ function(add_threads_if_needed)
   set(THREADS_PREFER_PTHREAD_FLAG ON)
   find_package(Threads REQUIRED)
   set_target_properties(Threads::Threads PROPERTIES IMPORTED_GLOBAL TRUE)
-
-  if(MINGW)
-    #[=[
-    mingw32's implementation of thread_local has been shown to behave
-    erroneously under concurrent usage.
-    See:
-     - https://github.com/bitcoin/bitcoin/pull/15849
-     - https://gist.github.com/jamesob/fe9a872051a88b2025b1aa37bfa98605
-    ]=]
-  elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
-    #[=[
-    FreeBSD's implementation of thread_local is buggy.
-    See:
-     - https://github.com/bitcoin/bitcoin/pull/16059
-     - https://groups.google.com/d/msg/bsdmailinglist/22ncTZAbDp4/Dii_pII5AwAJ
-    ]=]
-  elseif(ENABLE_THREADLOCAL)
-    target_compile_definitions(core_interface INTERFACE
-      "$<$<COMPILE_FEATURES:cxx_thread_local>:HAVE_THREAD_LOCAL>"
-    )
-  endif()
+  target_compile_definitions(core_interface INTERFACE HAVE_THREAD_LOCAL)
 endfunction()


### PR DESCRIPTION
This PR ports https://github.com/bitcoin/bitcoin/pull/30137.

The `target_compile_definitions` command is to be deleted during the next sync/rebase round. Such an early porting is needed for https://github.com/hebasto/bitcoin/pull/93 in order to delete the only non-config related generator expression from the compile definitions, which simplifies the summary code a lot.

Effectively, this commit has been split from https://github.com/hebasto/bitcoin/pull/93.