### PR TITLE
cmake: Implement `translate` target

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -297,3 +297,60 @@ install(TARGETS ${installable_targets}
 if(BUILD_GUI_TESTS)
   add_subdirectory(test)
 endif()
+
+
+# Gets sources to be parsed to gather translatable strings.
+function(get_translatable_sources var)
+  set(result)
+  set(targets)
+  foreach(dir IN ITEMS ${ARGN})
+    get_directory_property(dir_targets DIRECTORY ${PROJECT_SOURCE_DIR}/${dir} BUILDSYSTEM_TARGETS)
+    list(APPEND targets ${dir_targets})
+  endforeach()
+  foreach(target IN LISTS targets)
+    get_target_property(target_sources ${target} SOURCES)
+    if(target_sources)
+      foreach(source IN LISTS target_sources)
+        # Get an expression from the generator expression, if any.
+        if(source MATCHES ":([^>]+)>$")
+          set(source ${CMAKE_MATCH_1})
+        endif()
+        cmake_path(GET source EXTENSION LAST_ONLY ext)
+        if(ext STREQUAL ".qrc")
+          continue()
+        endif()
+        if(NOT IS_ABSOLUTE source)
+          get_target_property(target_source_dir ${target} SOURCE_DIR)
+          cmake_path(APPEND target_source_dir ${source} OUTPUT_VARIABLE source)
+        endif()
+        list(APPEND result ${source})
+      endforeach()
+    endif()
+  endforeach()
+  set(${var} ${result} PARENT_SCOPE)
+endfunction()
+
+find_program(XGETTEXT_EXECUTABLE xgettext)
+find_program(SED_EXECUTABLE sed)
+if(NOT XGETTEXT_EXECUTABLE)
+  add_custom_target(translate
+    COMMAND ${CMAKE_COMMAND} -E echo "Error: GNU gettext-tools not found"
+  )
+elseif(NOT SED_EXECUTABLE)
+  add_custom_target(translate
+    COMMAND ${CMAKE_COMMAND} -E echo "Error: GNU sed not found"
+  )
+else()
+  get_translatable_sources(translatable_sources src src/qt src/util src/wallet)
+  get_translatable_sources(qt_translatable_sources src/qt)
+  file(GLOB ui_files ${CMAKE_CURRENT_SOURCE_DIR}/forms/*.ui)
+  add_custom_target(translate
+    COMMAND ${CMAKE_COMMAND} -E env XGETTEXT=${XGETTEXT_EXECUTABLE} COPYRIGHT_HOLDERS=${COPYRIGHT_HOLDERS} ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/share/qt/extract_strings_qt.py ${translatable_sources}
+    COMMAND Qt5::lupdate -no-obsolete -I ${PROJECT_SOURCE_DIR}/src -locations relative ${CMAKE_CURRENT_SOURCE_DIR}/bitcoinstrings.cpp ${ui_files} ${qt_translatable_sources} -ts ${CMAKE_CURRENT_SOURCE_DIR}/locale/bitcoin_en.ts
+    COMMAND Qt5::lconvert -drop-translations -o ${CMAKE_CURRENT_SOURCE_DIR}/locale/bitcoin_en.xlf -i ${CMAKE_CURRENT_SOURCE_DIR}/locale/bitcoin_en.ts
+    COMMAND ${SED_EXECUTABLE} -i.old -e "s|source-language=\"en\" target-language=\"en\"|source-language=\"en\"|" -e "/<target xml:space=\"preserve\"><\\/target>/d" ${CMAKE_CURRENT_SOURCE_DIR}/locale/bitcoin_en.xlf
+    COMMAND ${CMAKE_COMMAND} -E rm ${CMAKE_CURRENT_SOURCE_DIR}/locale/bitcoin_en.xlf.old
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src
+    VERBATIM
+  )
+endif()

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -76,36 +76,67 @@ qt5_add_translation(qm_files ${ts_files})
 
 configure_file(bitcoin_locale.qrc bitcoin_locale.qrc COPYONLY)
 
+# The bitcoinqt sources have to include headers in
+# order to parse them to collect translatable strings.
 add_library(bitcoinqt STATIC EXCLUDE_FROM_ALL
   bantablemodel.cpp
+  bantablemodel.h
   bitcoin.cpp
+  bitcoin.h
   bitcoinaddressvalidator.cpp
+  bitcoinaddressvalidator.h
   bitcoinamountfield.cpp
+  bitcoinamountfield.h
   bitcoingui.cpp
+  bitcoingui.h
   bitcoinunits.cpp
+  bitcoinunits.h
   clientmodel.cpp
+  clientmodel.h
   csvmodelwriter.cpp
+  csvmodelwriter.h
   guiutil.cpp
+  guiutil.h
   initexecutor.cpp
+  initexecutor.h
   intro.cpp
-  modaloverlay.cpp
-  networkstyle.cpp
-  notificator.cpp
-  optionsdialog.cpp
-  optionsmodel.cpp
-  peertablemodel.cpp
-  peertablesortproxy.cpp
-  platformstyle.cpp
-  qvalidatedlineedit.cpp
-  qvaluecombobox.cpp
-  rpcconsole.cpp
-  splashscreen.cpp
-  trafficgraphwidget.cpp
-  utilitydialog.cpp
-  $<$<PLATFORM_ID:Windows>:winshutdownmonitor.cpp>
+  intro.h
+  $<$<PLATFORM_ID:Darwin>:macdockiconhandler.h>
   $<$<PLATFORM_ID:Darwin>:macdockiconhandler.mm>
+  $<$<PLATFORM_ID:Darwin>:macnotificationhandler.h>
   $<$<PLATFORM_ID:Darwin>:macnotificationhandler.mm>
+  $<$<PLATFORM_ID:Darwin>:macos_appnap.h>
   $<$<PLATFORM_ID:Darwin>:macos_appnap.mm>
+  modaloverlay.cpp
+  modaloverlay.h
+  networkstyle.cpp
+  networkstyle.h
+  notificator.cpp
+  notificator.h
+  optionsdialog.cpp
+  optionsdialog.h
+  optionsmodel.cpp
+  optionsmodel.h
+  peertablemodel.cpp
+  peertablemodel.h
+  peertablesortproxy.cpp
+  peertablesortproxy.h
+  platformstyle.cpp
+  platformstyle.h
+  qvalidatedlineedit.cpp
+  qvalidatedlineedit.h
+  qvaluecombobox.cpp
+  qvaluecombobox.h
+  rpcconsole.cpp
+  rpcconsole.h
+  splashscreen.cpp
+  splashscreen.h
+  trafficgraphwidget.cpp
+  trafficgraphwidget.h
+  utilitydialog.cpp
+  utilitydialog.h
+  $<$<PLATFORM_ID:Windows>:winshutdownmonitor.cpp>
+  $<$<PLATFORM_ID:Windows>:winshutdownmonitor.h>
   bitcoin.qrc
   ${CMAKE_CURRENT_BINARY_DIR}/bitcoin_locale.qrc
 )
@@ -141,35 +172,65 @@ if(ENABLE_WALLET)
   target_sources(bitcoinqt
     PRIVATE
       addressbookpage.cpp
+      addressbookpage.h
       addresstablemodel.cpp
+      addresstablemodel.h
       askpassphrasedialog.cpp
+      askpassphrasedialog.h
       coincontroldialog.cpp
+      coincontroldialog.h
       coincontroltreewidget.cpp
+      coincontroltreewidget.h
       createwalletdialog.cpp
+      createwalletdialog.h
       editaddressdialog.cpp
+      editaddressdialog.h
       openuridialog.cpp
+      openuridialog.h
       overviewpage.cpp
+      overviewpage.h
       paymentserver.cpp
+      paymentserver.h
       psbtoperationsdialog.cpp
+      psbtoperationsdialog.h
       qrimagewidget.cpp
+      qrimagewidget.h
       receivecoinsdialog.cpp
+      receivecoinsdialog.h
       receiverequestdialog.cpp
+      receiverequestdialog.h
       recentrequeststablemodel.cpp
+      recentrequeststablemodel.h
       sendcoinsdialog.cpp
+      sendcoinsdialog.h
       sendcoinsentry.cpp
+      sendcoinsentry.h
       signverifymessagedialog.cpp
+      signverifymessagedialog.h
       transactiondesc.cpp
+      transactiondesc.h
       transactiondescdialog.cpp
+      transactiondescdialog.h
       transactionfilterproxy.cpp
+      transactionfilterproxy.h
       transactionoverviewwidget.cpp
+      transactionoverviewwidget.h
       transactionrecord.cpp
+      transactionrecord.h
       transactiontablemodel.cpp
+      transactiontablemodel.h
       transactionview.cpp
+      transactionview.h
       walletcontroller.cpp
+      walletcontroller.h
       walletframe.cpp
+      walletframe.h
       walletmodel.cpp
+      walletmodel.h
       walletmodeltransaction.cpp
+      walletmodeltransaction.h
       walletview.cpp
+      walletview.h
   )
   target_link_libraries(bitcoinqt
     PRIVATE


### PR DESCRIPTION
The suggested steps to test:

1. Run Autotools' `make translate`:
```
$ ./autogen.sh && ./configure --with-incompatible-bdb
$ make -C src translate
```
2. Commit changes.
3. Then build CMake's `translate` target:
```
$ cmake -B build -DBUILD_GUI=ON -DWITH_BDB=ON
$ cmake --build build -t translate
```
No new changes must be introduced.