### PR TITLE
cmake: Do not add rpath information to compiled executables

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -360,6 +360,7 @@ jobs:
         working-directory: depends
         run: |
           make -j$(nproc) HOST=${{ matrix.host.triplet }} CC="${{ matrix.host.c_compiler }}" CXX="${{ matrix.host.cxx_compiler }}" ${{ matrix.host.depends_options }} LOG=1 NO_UPNP=1
+          echo "LD_LIBRARY_PATH=${PWD}/${{ matrix.host.triplet }}/lib" >> "$GITHUB_ENV"
 
       - name: Restore Ccache cache
         uses: actions/cache/restore@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -594,6 +594,7 @@ if(DEFINED ENV{LDFLAGS})
   deduplicate_flags(CMAKE_EXE_LINKER_FLAGS)
 endif()
 
+set(CMAKE_SKIP_RPATH TRUE)
 add_subdirectory(src)
 add_subdirectory(test)
 add_subdirectory(doc)


### PR DESCRIPTION
See https://github.com/bitcoin/bitcoin/pull/30312.

To test this PR, please cherry-pick a commit from https://github.com/bitcoin/bitcoin/pull/30312 and do Guix build.