### PR TITLE
cmake: Keep RPATH for the `bitcoin-chainstate` target in the build tree

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -262,6 +262,69 @@ jobs:
           ./install/bin/bitcoind -version
 
 
+  ubuntu-chainstate:
+    name: 'Ubuntu, chainstate + ${{ matrix.conf.job_name }} libkernel'
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        conf:
+          - shared_libs: '-DBUILD_SHARED_LIBS=OFF'
+            job_name: 'STATIC'
+          - shared_libs: '-DBUILD_SHARED_LIBS=ON'
+            job_name: 'SHARED'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends ccache libboost-dev libevent-dev
+          echo "CCACHE_DIR=${{ runner.temp }}/ccache" >> "$GITHUB_ENV"
+
+      - name: CMake version
+        run: |
+          cmake --version
+          ctest --version
+
+      - name: Restore Ccache cache
+        uses: actions/cache/restore@v4
+        id: ccache-cache
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ github.job }}-ccache-${{ github.run_id }}
+          restore-keys: ${{ github.job }}-${{ matrix.conf.job_name }}-ccache-
+
+      - name: Generate build system
+        run: |
+          cmake -B build -DBUILD_UTIL_CHAINSTATE=ON ${{ matrix.conf.shared_libs }}
+
+      - name: Build
+        working-directory: build
+        run: |
+          ccache --zero-stats
+          cmake --build . -j $(nproc) --target bitcoin-chainstate
+
+      - name: Ccache stats
+        run: |
+          ccache --version | head -n 1
+          ccache --show-stats
+
+      - name: Save Ccache cache
+        uses: actions/cache/save@v4
+        if: github.event_name != 'pull_request' && steps.ccache-cache.outputs.cache-hit != 'true'
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ github.job }}-${{ matrix.conf.job_name }}-ccache-${{ github.run_id }}
+
+      - name: Run bitcoin-chainstate
+        run: |
+          ./build/src/bitcoin-chainstate || [[ $? -eq 1 ]]
+
+
   cross-build:
     name: ${{ matrix.host.name }}
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,7 +597,14 @@ if(DEFINED ENV{LDFLAGS})
   deduplicate_flags(CMAKE_EXE_LINKER_FLAGS)
 endif()
 
-set(CMAKE_SKIP_RPATH TRUE)
+# TODO: The `CMAKE_SKIP_BUILD_RPATH` variable setting can be deleted
+#       in the future after reordering Guix script commands to
+#       perform binary checks after the installation step.
+# Relevant discussions:
+# - https://github.com/hebasto/bitcoin/pull/236#issuecomment-2183120953
+# - https://github.com/bitcoin/bitcoin/pull/30312#issuecomment-2191235833
+set(CMAKE_SKIP_BUILD_RPATH TRUE)
+set(CMAKE_SKIP_INSTALL_RPATH TRUE)
 add_subdirectory(src)
 add_subdirectory(test)
 add_subdirectory(doc)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -355,6 +355,15 @@ if(BUILD_UTIL_CHAINSTATE)
   add_executable(bitcoin-chainstate
     bitcoin-chainstate.cpp
   )
+  # TODO: The `SKIP_BUILD_RPATH` property setting can be deleted
+  #       in the future after reordering Guix script commands to
+  #       perform binary checks after the installation step.
+  # Relevant discussions:
+  # - https://github.com/hebasto/bitcoin/pull/236#issuecomment-2183120953
+  # - https://github.com/bitcoin/bitcoin/pull/30312#issuecomment-2191235833
+  set_target_properties(bitcoin-chainstate PROPERTIES
+    SKIP_BUILD_RPATH OFF
+  )
   target_link_libraries(bitcoin-chainstate
     PRIVATE
       core_interface


### PR DESCRIPTION
This is a follow-up of https://github.com/bitcoin/bitcoin/pull/30312 and https://github.com/hebasto/bitcoin/pull/236.

On staging branch @ 8b80c1a3f80509f6c07f24d91176042885961ea5:
```
$ cmake -B build -DBUILD_UTIL_CHAINSTATE=ON -DBUILD_SHARED_LIBS=ON
$ cmake --build build -t bitcoin-chainstate
$ ./build/src/bitcoin-chainstate
./build/src/bitcoin-chainstate: error while loading shared libraries: libbitcoinkernel.so: cannot open shared object file: No such file or directory
```

This PR fixes this issue and adds a new CI job to check it.
