### PR TITLE
cmake: Drop Libtool's option

### DIFF
--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -90,10 +90,6 @@ target_link_libraries(bitcoinkernel
   PUBLIC
     Boost::headers
 )
-target_link_options(bitcoinkernel
-  PRIVATE
-    LINKER:-no-undefined
-)
 
 # libbitcoinkernel requires default symbol visibility, explicitly
 # specify that here so that things still work even when user


### PR DESCRIPTION
The `-no-undefined` is not a linker flag, rather a Libtool flag, which we do not care about.