### PR TITLE
[FIXUP] cmake: Enable CMP0141 policy after `cmake_minimum_required()`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,13 @@
 #
 # Centos Stream 9, EOL in May 2027:
 #  - CMake 3.26.5, https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/
+cmake_minimum_required(VERSION 3.22)
 if(POLICY CMP0141)
   # MSVC debug information format flags are selected by an abstraction.
   # We want to use the CMAKE_MSVC_DEBUG_INFORMATION_FORMAT variable
   # to select the MSVC debug information format.
   cmake_policy(SET CMP0141 NEW)
 endif()
-cmake_minimum_required(VERSION 3.22)
 
 #=============================
 # Project / Package metadata


### PR DESCRIPTION
Otherwise, the policy setting won't get any effect.

See https://cmake.org/cmake/help/latest/policy/CMP0141.html

---

After https://github.com/hebasto/bitcoin/pull/215, the `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT` CMake's abstraction is not used in our code directly, but it is still convenient for the user to be able to use it when configuring the build system from the command line or an IDE.

---

This change can be easily verified on any system (not Windows only) by injecting the following commands:
```cmake
cmake_policy(GET CMP0141 result)
message("${result}")
```