### PR TITLE
more macOS testing feedback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,9 +134,11 @@ if(WITH_ZMQ)
   endif()
 endif()
 
+if(UNIX AND NOT APPLE)
 option(WITH_USDT "Enable tracepoints for Userspace, Statically Defined Tracing." OFF)
 if(WITH_USDT)
   find_package(USDT MODULE REQUIRED)
+endif()
 endif()
 
 cmake_dependent_option(ENABLE_EXTERNAL_SIGNER "Enable external signer support." ON "NOT WIN32" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,8 +164,10 @@ endif()
 
 cmake_dependent_option(BUILD_GUI_TESTS "Build test_bitcoin-qt executable." ON "BUILD_GUI;BUILD_TESTS" OFF)
 option(BUILD_BENCH "Build bench_bitcoin executable." OFF)
+if(UNIX AND NOT APPLE)
 option(BUILD_FUZZ_BINARY "Build fuzz binary." OFF)
 cmake_dependent_option(ENABLE_FUZZ "Build for fuzzing. Enabling this will disable all other targets and override BUILD_FUZZ_BINARY." OFF "NOT MSVC" OFF)
+endif()
 
 option(INSTALL_MAN "Install man pages." ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,10 +154,12 @@ endif()
 
 cmake_dependent_option(WITH_DBUS "Enable DBus support." ON "CMAKE_SYSTEM_NAME STREQUAL \"Linux\" AND BUILD_GUI" OFF)
 
+if(UNIX AND NOT APPLE)
 option(WITH_MULTIPROCESS "Build multiprocess bitcoin-node and bitcoin-gui executables in addition to monolithic bitcoind and bitcoin-qt executables. Requires libmultiprocess library. Experimental." OFF)
 if(WITH_MULTIPROCESS)
   find_package(Libmultiprocess CONFIG REQUIRED)
   find_package(LibmultiprocessGen CONFIG REQUIRED)
+endif()
 endif()
 
 cmake_dependent_option(BUILD_GUI_TESTS "Build test_bitcoin-qt executable." ON "BUILD_GUI;BUILD_TESTS" OFF)


### PR DESCRIPTION
brew install libnatpmp qrencode cppzmq

https://github.com/hebasto/bitcoin/assets/152159/2a609840-40f5-4e78-94ff-6563847edc51

cmake version 3.29.2
Darwin DeepSpaceMBPro.local 22.6.0 Darwin Kernel Version 22.6.0: Wed Jul  5 22:21:56 PDT 2023; root:xnu-8796.141.3~6/RELEASE_X86_64 x86_64


changes below were used to generate ```build``` on macOS Ventura 13.5 (22G74)

