### PR TITLE
cmake: Fix build with `-DENABLE_HARDENING=OFF`

### DIFF
--- a/cmake/crc32c.cmake
+++ b/cmake/crc32c.cmake
@@ -87,7 +87,7 @@ target_compile_definitions(crc32c_common INTERFACE
 )
 target_link_libraries(crc32c_common INTERFACE
   core_base_interface
-  hardening_interface
+  $<TARGET_NAME_IF_EXISTS:hardening_interface>
 )
 
 add_library(crc32c STATIC EXCLUDE_FROM_ALL

--- a/cmake/leveldb.cmake
+++ b/cmake/leveldb.cmake
@@ -96,7 +96,7 @@ endif()
 
 target_link_libraries(leveldb PRIVATE
   core_base_interface
-  hardening_interface
+  $<TARGET_NAME_IF_EXISTS:hardening_interface>
   nowarn_leveldb_interface
   crc32c
 )

--- a/cmake/minisketch.cmake
+++ b/cmake/minisketch.cmake
@@ -55,7 +55,7 @@ if(HAVE_CLMUL)
   target_link_libraries(minisketch_clmul
     PRIVATE
       core_base_interface
-      hardening_interface
+      $<TARGET_NAME_IF_EXISTS:hardening_interface>
       minisketch_common
   )
   set_target_properties(minisketch_clmul PROPERTIES
@@ -83,7 +83,7 @@ target_include_directories(minisketch
 target_link_libraries(minisketch
   PRIVATE
     core_base_interface
-    hardening_interface
+    $<TARGET_NAME_IF_EXISTS:hardening_interface>
     minisketch_common
     $<TARGET_NAME_IF_EXISTS:minisketch_clmul>
 )


### PR DESCRIPTION
On the staging branch @ a7cc7d8c4de5dfa0f90933dd67c6e6756683504f:
```
$ cmake -B build -DENABLE_HARDENING=OFF
$ cmake --build build
...
/usr/bin/ld: cannot find -lhardening_interface: No such file or directory
...
```

This PR fixes this issue.