### PR TITLE
cmake: Remove log lines from between libsecp's and Core's summaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,6 +374,17 @@ if(SANITIZERS)
 endif()
 target_link_options(sanitize_interface INTERFACE ${SANITIZER_LDFLAGS})
 
+if(BUILD_FUZZ_BINARY)
+  include(CheckSourceCompilesAndLinks)
+  check_cxx_source_links_with_flags("${SANITIZER_LDFLAGS}" "
+      #include <cstdint>
+      #include <cstddef>
+      extern \"C\" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) { return 0; }
+      // No main() function.
+    " FUZZ_BINARY_LINKS_WITHOUT_MAIN_FUNCTION
+  )
+endif()
+
 include(AddBoostIfNeeded)
 add_boost_if_needed()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,23 @@ if(WITH_MULTIPROCESS)
 endif()
 
 cmake_dependent_option(BUILD_GUI_TESTS "Build test_bitcoin-qt executable." ON "BUILD_GUI;BUILD_TESTS" OFF)
+if(BUILD_GUI)
+  set(qt_components Core Gui Widgets LinguistTools)
+  if(ENABLE_WALLET)
+    list(APPEND qt_components Network)
+  endif()
+  if(WITH_DBUS)
+    list(APPEND qt_components DBus)
+  endif()
+  if(BUILD_GUI_TESTS)
+    list(APPEND qt_components Test)
+  endif()
+  find_package(Qt5 5.11.3 MODULE REQUIRED
+    COMPONENTS ${qt_components}
+  )
+  unset(qt_components)
+endif()
+
 option(BUILD_BENCH "Build bench_bitcoin executable." OFF)
 option(BUILD_FUZZ_BINARY "Build fuzz binary." OFF)
 cmake_dependent_option(ENABLE_FUZZ "Build for fuzzing. Enabling this will disable all other targets and override BUILD_FUZZ_BINARY." OFF "NOT MSVC" OFF)

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -341,7 +341,11 @@ elseif(NOT SED_EXECUTABLE)
     COMMAND ${CMAKE_COMMAND} -E echo "Error: GNU sed not found"
   )
 else()
-  get_translatable_sources(translatable_sources src src/qt src/util src/wallet)
+  set(translatable_sources_directories src src/qt src/util)
+  if(ENABLE_WALLET)
+    list(APPEND translatable_sources_directories src/wallet)
+  endif()
+  get_translatable_sources(translatable_sources ${translatable_sources_directories})
   get_translatable_sources(qt_translatable_sources src/qt)
   file(GLOB ui_files ${CMAKE_CURRENT_SOURCE_DIR}/forms/*.ui)
   add_custom_target(translate

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -11,8 +11,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   string(APPEND CMAKE_OBJCXX_COMPILE_OBJECT " ${APPEND_CPPFLAGS} ${APPEND_CXXFLAGS}")
 endif()
 
+get_target_property(qt_lib_type Qt5::Core TYPE)
+
 function(import_plugins target)
-  if(QT_IS_STATIC)
+  if(qt_lib_type STREQUAL "STATIC_LIBRARY")
     set(plugins Qt5::QMinimalIntegrationPlugin)
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
       list(APPEND plugins Qt5::QXcbIntegrationPlugin)
@@ -36,21 +38,6 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOUIC_SEARCH_PATHS forms)
-
-include(CMakePushCheckState)
-cmake_push_check_state(RESET)
-set(CMAKE_REQUIRED_LIBRARIES Qt5::Core)
-include(CheckCXXSourceCompiles)
-check_cxx_source_compiles("
-  #include <QtGlobal>
-
-  #if !defined(QT_STATIC)
-  #error Qt is not static
-  #endif
-  int main() {}
-  " QT_IS_STATIC
-)
-cmake_pop_check_state()
 
 # TODO: The file(GLOB ...) command should be replaced with an explicit
 # file list. Such a change must be synced with the corresponding change
@@ -229,7 +216,7 @@ if(WITH_DBUS)
   target_link_libraries(bitcoinqt PRIVATE Qt5::DBus)
 endif()
 
-if(QT_IS_STATIC)
+if(qt_lib_type STREQUAL "STATIC_LIBRARY")
   # We want to define static plugins to link ourselves, thus preventing
   # automatic linking against a "sane" set of default static plugins.
   qt5_import_plugins(bitcoinqt

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -2,21 +2,6 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
-set(qt_components Core Gui Widgets LinguistTools)
-if(ENABLE_WALLET)
-  list(APPEND qt_components Network)
-endif()
-if(WITH_DBUS)
-  list(APPEND qt_components DBus)
-endif()
-if(BUILD_GUI_TESTS)
-  list(APPEND qt_components Test)
-endif()
-find_package(Qt5 5.11.3 MODULE REQUIRED
-  COMPONENTS ${qt_components}
-)
-unset(qt_components)
-
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   enable_language(OBJCXX)
   set(CMAKE_OBJCXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")

--- a/src/test/fuzz/util/CMakeLists.txt
+++ b/src/test/fuzz/util/CMakeLists.txt
@@ -18,14 +18,6 @@ target_link_libraries(test_fuzz
     Boost::headers
 )
 
-include(CheckSourceCompilesAndLinks)
-check_cxx_source_links_with_flags("${SANITIZER_LDFLAGS}" "
-    #include <cstdint>
-    #include <cstddef>
-    extern \"C\" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) { return 0; }
-    // No main() function.
-  " FUZZ_BINARY_LINKS_WITHOUT_MAIN_FUNCTION
-)
 if(NOT FUZZ_BINARY_LINKS_WITHOUT_MAIN_FUNCTION)
   target_compile_definitions(test_fuzz PRIVATE PROVIDE_FUZZ_MAIN_FUNCTION)
 endif()


### PR DESCRIPTION
This PR addresses https://github.com/hebasto/bitcoin/pull/192#discussion_r1660817378.

Additionally, fixed a bug in the `translate` target for the `-DBUILD_GUI=ON -DENABLE_WALLET=OFF` configuration.