### PR TITLE
cmake, doc: Fix comment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,8 @@ endif()
 unset(check_pie_output)
 
 # The core_interface library aims to encapsulate common build flags.
-# It is intended to be a usage requirement for all other targets.
+# It is a usage requirement for all targets except for secp256k1, which
+# gets its flags by other means.
 add_library(core_interface INTERFACE)
 add_library(core_interface_relwithdebinfo INTERFACE)
 add_library(core_interface_debug INTERFACE)


### PR DESCRIPTION
This PR addresses https://github.com/hebasto/bitcoin/pull/255#discussion_r1665374443:

> I think this documentation should have been updated? `core_interface` is a requirement for all targets now?