### PR TITLE
cmake: Port PR30263 from the master branch

### DIFF
--- a/ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
+++ b/ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
@@ -7,8 +7,8 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_nowallet_libbitcoinkernel
-export CI_IMAGE_NAME_TAG="docker.io/debian:bullseye"
-# Use minimum supported python3.9 and clang-16, see doc/dependencies.md
+export CI_IMAGE_NAME_TAG="docker.io/ubuntu:24.04"
+# Use minimum supported python3.9 (or best-effort 3.12) and clang-16, see doc/dependencies.md
 export PACKAGES="python3-zmq clang-16 llvm-16 libc++abi-16-dev libc++-16-dev"
 export DEP_OPTS="NO_WALLET=1 CC=clang-16 CXX='clang++-16 -stdlib=libc++'"
 export GOAL="install"


### PR DESCRIPTION
This PR ports CI-related changes from https://github.com/bitcoin/bitcoin/pull/30263 and ensures that the minimum required CMake version is available.

Here are CMake versions across all changes:
- pre-PR30263: CMake [3.22.1](https://packages.ubuntu.com/jammy/cmake)
- post-PR30263: CMake [3.18.4](https://packages.debian.org/bullseye/cmake), which is less than the minimum required 3.22
- this PR: CMake [3.28.3](https://packages.ubuntu.com/noble/cmake)