### PR TITLE
[FIXUP] cmake: Add missed `OBJC_OLD_DISPATCH_PROTOTYPES=0`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,7 @@ endif()
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   target_compile_definitions(core_interface INTERFACE
     MAC_OSX
+    OBJC_OLD_DISPATCH_PROTOTYPES=0
   )
   # These flags are specific to ld64, and may cause issues with other linkers.
   # For example: GNU ld will interpret -dead_strip as -de and then try and use


### PR DESCRIPTION
This PR addresses https://github.com/hebasto/bitcoin/issues/260#issuecomment-2227309231.