### PR TITLE
cmake, ci: Ignore `-Wmaybe-uninitialized` for GCC 11.4

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -231,7 +231,7 @@ jobs:
 
       - name: Generate build system
         run: |
-          cmake -B build --preset ci-linux -DBoost_INCLUDE_DIR="${PWD}/${{ matrix.conf.boost_archive }}"
+          cmake -B build --preset ci-linux -DBoost_INCLUDE_DIR="${PWD}/${{ matrix.conf.boost_archive }}" -DCMAKE_CXX_FLAGS="-Wno-error=maybe-uninitialized"
 
       - name: Build
         working-directory: build


### PR DESCRIPTION
This PR adds `-Wno-error=maybe-uninitialized` for GCC 11.4.

See: https://github.com/bitcoin/bitcoin/pull/29720#issuecomment-2223943553.