### PR TITLE
cmake: Report skipped tests properly

### DIFF
--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -39,6 +39,9 @@ if(TARGET test_bitcoin)
       add_test(NAME ${test_suite_name}
         COMMAND test_bitcoin --run_test=${test_suite_name} --catch_system_error=no
       )
+      set_property(TEST ${test_suite_name} PROPERTY
+        SKIP_REGULAR_EXPRESSION "no test cases matching filter" "Skipping"
+      )
     endif()
   endfunction()
 

--- a/src/test/compilerbug_tests.cpp
+++ b/src/test/compilerbug_tests.cpp
@@ -6,13 +6,6 @@
 
 BOOST_AUTO_TEST_SUITE(compilerbug_tests)
 
-// At least one test case is required to avoid the "Test setup error: no test
-// cases matching filter or all test cases were disabled" errror.
-BOOST_AUTO_TEST_CASE(dummy)
-{
-    BOOST_CHECK(true);
-}
-
 #if defined(__GNUC__)
 // This block will also be built under clang, which is fine (as it supports noinline)
 void __attribute__ ((noinline)) set_one(unsigned char* ptr)


### PR DESCRIPTION
CMake allows to report about skipped tests properly instead of passing dummy test cases. For instance, on Windows:
```
> ctest --build-config Release -R compilerbug
Test project C:/Users/hebasto/source/repos/bitcoin/build
    Start 26: compilerbug_tests
1/1 Test #26: compilerbug_tests ................***Skipped   0.02 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.04 sec

The following tests did not run:
         26 - compilerbug_tests (Skipped)
```

We have 3 such cases:
- `src/test/compilerbug_tests.cpp`
- `src/test/raii_event_tests.cpp`
- `src/test/system_tests.cpp`

This PR handles the first two cases.

Once https://github.com/bitcoin/bitcoin/pull/30454 is merged, the following lines can be deleted: https://github.com/hebasto/bitcoin/blob/9b4aa929b0e84e64472402e594ebb13648bac878/src/test/system_tests.cpp#L19-L25