### PR TITLE
cmake: Allow overriding flags in compiler/linker flag checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,22 @@ set(CLIENT_VERSION_RC 0)
 set(CLIENT_VERSION_IS_RELEASE "false")
 set(COPYRIGHT_YEAR "2024")
 
+# During the enabling of the CXX and CXXOBJ languages, we modify
+# CMake's compiler/linker invocation strings by appending the content
+# of the user-defined `APPEND_*` variables, which allows overriding
+# any flag. We also ensure that the APPEND_* flags are considered
+# during CMake's tests, which use the `try_compile()` command.
+#
+# CMake's docs state that the `CMAKE_TRY_COMPILE_PLATFORM_VARIABLES`
+# variable "is meant to be set by CMake's platform information modules
+# for the current toolchain, or by a toolchain file." We do our best
+# to set it before the `project()` command.
+set(CMAKE_TRY_COMPILE_PLATFORM_VARIABLES
+  CMAKE_CXX_COMPILE_OBJECT
+  CMAKE_OBJCXX_COMPILE_OBJECT
+  CMAKE_CXX_LINK_EXECUTABLE
+)
+
 project(BitcoinCore
   VERSION ${CLIENT_VERSION_MAJOR}.${CLIENT_VERSION_MINOR}.${CLIENT_VERSION_BUILD}
   DESCRIPTION "Bitcoin client software"


### PR DESCRIPTION
The `APPEND_{CPP,C,CXX,LD}FLAGS` flags are now considered when checking compiler/linker flags.

Fixes https://github.com/hebasto/bitcoin/issues/279.