### PR TITLE
cmake: Drop unused packages from Guix manifest

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -1,5 +1,4 @@
 (use-modules (gnu packages)
-             (gnu packages autotools)
              ((gnu packages bash) #:select (bash-minimal))
              (gnu packages bison)
              ((gnu packages certs) #:select (nss-certs))
@@ -522,9 +521,6 @@ inspecting signatures in Mach-O binaries.")
         gcc-toolchain-12
         cmake-minimal
         gnu-make
-        libtool
-        autoconf-2.71
-        automake
         pkg-config
         ;; Scripting
         python-minimal ;; (3.10)


### PR DESCRIPTION
Autotools installation is not required at this moment.

~Drafted because of this~ [feedback](https://github.com/bitcoin/bitcoin/pull/30454#discussion_r1699904124):
> Autotools might not be used currently for sqlite (libtool still is), but we can't rule out entirely that it wont be used going forward. For example, if we need to regenerate the configure script for some reason. This has happened in the past, for example, something like [6897c4b](https://github.com/bitcoin/bitcoin/commit/6897c4bdf51a4aa74320ebfffa9467db14670109). This might be very unlikely here, but not impossible.
> 
> Note that this would also breakdown, if we were to shift to building from source (requiring us to generate the build scripts oursevles), rather than using the tarballs with everything pre-generated (and unverifiable/opauge). (In this case it'd also be all of the Linux GUI packages that'd require it).

My Guix build:
```
x86_64
b21ad69710ffc70dac55c40fdb3287cdb50286aa434a590f2eb9eae943c2c1e6  guix-build-adee830febcf/output/aarch64-linux-gnu/SHA256SUMS.part
597a4c00582ea8be1eadfec43880fac7cb56b1df3257e3439b2eeb7fc4c33da2  guix-build-adee830febcf/output/aarch64-linux-gnu/bitcoin-adee830febcf-aarch64-linux-gnu-debug.tar.gz
8af7d4c70b6bcb69705e9124b0f19959e2a4c6eccffec9a97ad0a9e24ffc9cf1  guix-build-adee830febcf/output/aarch64-linux-gnu/bitcoin-adee830febcf-aarch64-linux-gnu.tar.gz
3289c81b14b1b44f1208b1297692ad4ba23c2e65aed43def95d6b6fc9937cc7c  guix-build-adee830febcf/output/arm-linux-gnueabihf/SHA256SUMS.part
1240e0a7b61352b8f532fb113653258266ac9ef3687b9e0920ab261c3702d7d6  guix-build-adee830febcf/output/arm-linux-gnueabihf/bitcoin-adee830febcf-arm-linux-gnueabihf-debug.tar.gz
25b118ddd8d5bbe54f56b259f48eba76fd62a5cee17f074972c33409480ffc91  guix-build-adee830febcf/output/arm-linux-gnueabihf/bitcoin-adee830febcf-arm-linux-gnueabihf.tar.gz
48c985c03352b5e5d7581bd9283321f4f9681e241b4c55ed6109ad2cb9fec738  guix-build-adee830febcf/output/arm64-apple-darwin/SHA256SUMS.part
4d6d1092b8208b5e0ff3af7bad1fa858eb9b52ff3acb091e876b6b509306d01f  guix-build-adee830febcf/output/arm64-apple-darwin/bitcoin-adee830febcf-arm64-apple-darwin-unsigned.tar.gz
8a7a69de4058c143190128867d7ff1a490035ec384f4dd913da799a8f15c62d3  guix-build-adee830febcf/output/arm64-apple-darwin/bitcoin-adee830febcf-arm64-apple-darwin-unsigned.zip
b949eccdb836537eae14486891d22769d8968b25da8921acc4f6873549380940  guix-build-adee830febcf/output/arm64-apple-darwin/bitcoin-adee830febcf-arm64-apple-darwin.tar.gz
0f86e37acc22ab04513f0e01e080ed48184c13e85577c0e523decf20aa8d1da5  guix-build-adee830febcf/output/dist-archive/bitcoin-adee830febcf.tar.gz
08060a7654c545b06bd8f00e0187dd0d57a7de335517b808d68f426191f5555e  guix-build-adee830febcf/output/powerpc64-linux-gnu/SHA256SUMS.part
c4fe227333a4bdeb05764b5fab04f0767c816b05e2217d92eba79b43048b8c65  guix-build-adee830febcf/output/powerpc64-linux-gnu/bitcoin-adee830febcf-powerpc64-linux-gnu-debug.tar.gz
4e724bcfd1f3f7aef93f8ea041cc92f5be0046980014dcefbbcb0af4c381508f  guix-build-adee830febcf/output/powerpc64-linux-gnu/bitcoin-adee830febcf-powerpc64-linux-gnu.tar.gz
fe2e0e81eb5b826c4e3bd6d1850a97c7330f499418c48498111c36e4df1fef13  guix-build-adee830febcf/output/riscv64-linux-gnu/SHA256SUMS.part
3d80dd507d41e1e98dad9f052dd5c52fe964dd141263a697e73e0498875eabb5  guix-build-adee830febcf/output/riscv64-linux-gnu/bitcoin-adee830febcf-riscv64-linux-gnu-debug.tar.gz
198f0e673ad26c62a1f8e2bdd805c8b045e0f0192f70f3895b3c4309782bd766  guix-build-adee830febcf/output/riscv64-linux-gnu/bitcoin-adee830febcf-riscv64-linux-gnu.tar.gz
3562bf0b37a1cca3034aaaa0a94e615d8dd673a231f3d21a01bee0e1c514eaaf  guix-build-adee830febcf/output/x86_64-apple-darwin/SHA256SUMS.part
4c4b44bb84de29aa8f86820905858d716233dcc4367ba808802ff60eae7892d0  guix-build-adee830febcf/output/x86_64-apple-darwin/bitcoin-adee830febcf-x86_64-apple-darwin-unsigned.tar.gz
3023370ed8950ab520df7dcfaa729007a1e02f69e79aa253b89baa6598ccc33b  guix-build-adee830febcf/output/x86_64-apple-darwin/bitcoin-adee830febcf-x86_64-apple-darwin-unsigned.zip
cdb7e48d90a45fd1517bcb96c9e503db0c616f474e7c2c7da16ead9788982f6d  guix-build-adee830febcf/output/x86_64-apple-darwin/bitcoin-adee830febcf-x86_64-apple-darwin.tar.gz
28e01eb9f129134211993d814fe6bbc1a856306dabb5c6271456062e42ce83e6  guix-build-adee830febcf/output/x86_64-linux-gnu/SHA256SUMS.part
4e7c5f359a2d15250783bd1dfa975812d63ba6600be7778569920ed07c99c1cd  guix-build-adee830febcf/output/x86_64-linux-gnu/bitcoin-adee830febcf-x86_64-linux-gnu-debug.tar.gz
7ff4823e63cfb0284857c4a24ca80b38bf12dd919d8201ee1a6d0bf70fe5bd0f  guix-build-adee830febcf/output/x86_64-linux-gnu/bitcoin-adee830febcf-x86_64-linux-gnu.tar.gz
8ef0174520bf5a47d61b6a3bf6b7e684939ab76901e2235affe8df509b3d835c  guix-build-adee830febcf/output/x86_64-w64-mingw32/SHA256SUMS.part
f145a5d7c1c0953a569e038d2d3a21d93a9abad48f4c36289893dacc67498bcc  guix-build-adee830febcf/output/x86_64-w64-mingw32/bitcoin-adee830febcf-win64-debug.zip
471d0b2724875c8c27c5197824a5eae382b052343f840727bfc2eb9c30873aa5  guix-build-adee830febcf/output/x86_64-w64-mingw32/bitcoin-adee830febcf-win64-setup-unsigned.exe
56a68aa63440bfcb6780ac536f4287eb4a56ffa868d3b27659970e0bd5a9efcd  guix-build-adee830febcf/output/x86_64-w64-mingw32/bitcoin-adee830febcf-win64-unsigned.tar.gz
b1bdf52ae1c0426379065c180c412b0ff569e8bd8fadaa597fd95a54414e9c3d  guix-build-adee830febcf/output/x86_64-w64-mingw32/bitcoin-adee830febcf-win64.zip
```