### PR TITLE
cmake: Temporarily revert removal of `Q_IMPORT_PLUGIN` macros

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -13,6 +13,9 @@ endif()
 
 get_target_property(qt_lib_type Qt5::Core TYPE)
 
+# TODO: After the transition from Autotools to CMake,
+#       all `Q_IMPORT_PLUGIN` macros can be deleted from the
+#       qt/bitcoin.cpp and qt/test/test_main.cpp source files.
 function(import_plugins target)
   if(qt_lib_type STREQUAL "STATIC_LIBRARY")
     set(plugins Qt5::QMinimalIntegrationPlugin)
@@ -24,8 +27,8 @@ function(import_plugins target)
       list(APPEND plugins Qt5::QCocoaIntegrationPlugin Qt5::QMacStylePlugin)
     endif()
     qt5_import_plugins(${target}
-        INCLUDE ${plugins}
-        EXCLUDE_BY_TYPE imageformats iconengines
+      INCLUDE ${plugins}
+      EXCLUDE_BY_TYPE imageformats iconengines
     )
   endif()
 endfunction()

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -60,6 +60,21 @@
 #include <QTranslator>
 #include <QWindow>
 
+#if defined(QT_STATIC)
+#include <QtPlugin>
+#if defined(QT_QPA_PLATFORM_XCB)
+Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
+#elif defined(QT_QPA_PLATFORM_WINDOWS)
+Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
+Q_IMPORT_PLUGIN(QWindowsVistaStylePlugin);
+#elif defined(QT_QPA_PLATFORM_COCOA)
+Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin);
+Q_IMPORT_PLUGIN(QMacStylePlugin);
+#elif defined(QT_QPA_PLATFORM_ANDROID)
+Q_IMPORT_PLUGIN(QAndroidPlatformIntegrationPlugin)
+#endif
+#endif
+
 // Declare meta types used for QMetaObject::invokeMethod
 Q_DECLARE_METATYPE(bool*)
 Q_DECLARE_METATYPE(CAmount)

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -28,6 +28,22 @@
 
 #include <functional>
 
+#if defined(QT_STATIC)
+#include <QtPlugin>
+#if defined(QT_QPA_PLATFORM_MINIMAL)
+Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin);
+#endif
+#if defined(QT_QPA_PLATFORM_XCB)
+Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
+#elif defined(QT_QPA_PLATFORM_WINDOWS)
+Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
+#elif defined(QT_QPA_PLATFORM_COCOA)
+Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin);
+#elif defined(QT_QPA_PLATFORM_ANDROID)
+Q_IMPORT_PLUGIN(QAndroidPlatformIntegrationPlugin)
+#endif
+#endif
+
 const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
 
 const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS{};


### PR DESCRIPTION
This PR aims to restore [compatibility](https://github.com/bitcoin/bitcoin/pull/30454#issuecomment-2236884983) of the CMake staging branch and https://github.com/bitcoin/bitcoin/pull/30454 with the Autotools-based build system.

On the staging branch @ f63b2002a1dcb53178626147d61bfd290e63d65b:
```
$ make -C depends
$ ./autogen.sh
$ ./configure CONFIG_SITE=$PWD/depends/x86_64-pc-linux-gnu/share/config.site
$ make -C src qt/bitcoin-qt
$ ./src/qt/bitcoin-qt
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Aborted (core dumped)
```

This PR resolves this issue and adds a TODO comment for the further actions.