### PR TITLE
cmake: Fix cross-compiling detection on OpenBSD

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -250,7 +250,7 @@ $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_
             $< > $@
 	touch $@
 
-ifeq ($(host),$(build))
+ifeq ($(canonical_host),$(build))
   crosscompiling=FALSE
 else
   crosscompiling=TRUE


### PR DESCRIPTION
To detect cross-compiling, the host and build platforms are compared. The `build` variable is always an output of `config.sub`, but the `host` is not. This can lead to false results. For example, on OpenBSD:
 - host=amd64-unknown-openbsd7.5
 - build=x86_64-unknown-openbsd7.5

This change replaces the `host` variable with `canonical_host`, which is also always an output of `config.sub`. Thus, `canonical_host` and `build` are always properly comparable.

---

There are a few same/similar cases in the master branch. So I'm going to investigate them further. and submit a PR.