### PR TITLE
cmake: Ignore build subdirectories within the source directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Build subdirectories.
+/*build*
+!/build-aux
+!/build_msvc
+
 *.tar.gz
 
 *.exe


### PR DESCRIPTION
It was planned to clean up the `.gitignore` file during the [removal](https://github.com/hebasto/bitcoin/pull/166) of the Autotools and MSVC legacy build systems. However, reviewers requested it [earlier](https://github.com/bitcoin/bitcoin/pull/30454#issuecomment-2267493946).

Therefore, [delivering](https://github.com/bitcoin/bitcoin/pull/30454#issuecomment-2268754162) it now :)