### PR TITLE
cmake: Fix `AddBoostIfNeeded` module

### DIFF
--- a/cmake/module/AddBoostIfNeeded.cmake
+++ b/cmake/module/AddBoostIfNeeded.cmake
@@ -60,6 +60,8 @@ function(add_boost_if_needed)
     target_compile_definitions(Boost::headers INTERFACE
       BOOST_NO_CXX98_FUNCTION_BASE
     )
+  else()
+    set(CMAKE_REQUIRED_DEFINITIONS)
   endif()
 
   if(BUILD_TESTS)


### PR DESCRIPTION
Cross-posted from https://github.com/bitcoin/bitcoin/pull/30454#discussion_r1706688706:
> Pretty sure there are two separate bugs here:
> 
>    * The first is that `BOOST_NO_CXX98_FUNCTION_BASE` isn't removed from `CMAKE_REQUIRED_DEFINITIONS` after this check, which means it's incorrectly reused for the check below.
> 
>    * The second is that when `-DWERROR=ON` is used, `-Werror` isn't being passed to the check for the Boost Test header (which also hides the first bug).

This PR addresses the first part (see the commit message for more details).

The second one remains unaddressed for the following reasons:
1. `-DWERROR=ON` (or `--enable-debug` in Autotools) was never used to control passing the `-Werror` flag to checks of any type.
2. In both build systems—Autotools and CMake—we do not use `-Werror` in check for header availability. It is not clear why `unit_test.hpp` should be an exception.

Please correct me if my understanding is wrong.