### PR TITLE
cmake: Forbid in-source builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ if(POLICY CMP0141)
   cmake_policy(SET CMP0141 NEW)
 endif()
 
+if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+  message(FATAL_ERROR "In-source builds are not allowed.")
+endif()
+
 #=============================
 # Project / Package metadata
 #=============================


### PR DESCRIPTION
In-source builds with CMake are incompatible with Autotools because the `Makefile` files are being overwritten.

This PR provides a clear error message if the user attempts to perform an in-source build.

Unfortunately, this approach does not prevent the source directory from being polluted with a few build artifacts. For more details, please see:
- https://discourse.cmake.org/t/preventing-in-source-builds/881
- https://gitlab.kitware.com/cmake/cmake/-/issues/6672

Resolves https://github.com/hebasto/bitcoin/issues/306.

---

The allowance of in-source builds can be reconsidered after completing the migration from Autotools.