### PR TITLE
cmake: Fix prefix maps for Guix builds

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -212,7 +212,7 @@ CONFIGFLAGS="-DREDUCE_EXPORTS=ON -DBUILD_BENCH=OFF -DBUILD_GUI_TESTS=OFF -DBUILD
 HOST_CFLAGS="-O2 -g"
 HOST_CFLAGS+=$(find /gnu/store -maxdepth 1 -mindepth 1 -type d -exec echo -n " -ffile-prefix-map={}=/usr" \;)
 case "$HOST" in
-    *linux*)  HOST_CFLAGS+=" -ffile-prefix-map=${PWD}=." ;;
+    *linux*)  HOST_CFLAGS+=" -ffile-prefix-map=${DISTSRC}/src=." ;;
     *mingw*)  HOST_CFLAGS+=" -fno-ident" ;;
     *darwin*) unset HOST_CFLAGS ;;
 esac


### PR DESCRIPTION
Fixes https://github.com/hebasto/bitcoin/issues/297.

CMake uses absolute paths for source files when invoking a compiler. This change makes the resulting Guix binaries location independent.

The resulting behaviour mirrors that of the master branch.

---

NOTE. On the master branch, `HOST_CFLAGS+=" -ffile-prefix-map=${PWD}=."` evaluates to `HOST_CFLAGS+=" -ffile-prefix-map=/bitcoin=."`, which effectively does nothing because there is no such a path among source files being compiled. Binaries appear file path independent because file paths relative to the source directory are used when invoking a compiler.