### PR TITLE
cmake: Port PR30051 from the master branch

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -148,6 +148,7 @@ target_link_libraries(test_bitcoin
   bitcoin_cli
   bitcoin_node
   minisketch
+  secp256k1
   Boost::headers
   $<TARGET_NAME_IF_EXISTS:libevent::libevent>
 )


### PR DESCRIPTION
This PR ports a single commit from https://github.com/bitcoin/bitcoin/pull/30051 and amends the `test_bitcoin` target to fix compiling.