### PR TITLE
cmake: Fix `cmake_install` scripts for macOS

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -275,6 +275,10 @@ mkdir -p "$DISTSRC"
     # Install built Bitcoin Core to $INSTALLPATH
     case "$HOST" in
         *darwin*)
+            # This workaround can be dropped for CMake >= 3.27.
+            # See the upstream commit 689616785f76acd844fd448c51c5b2a0711aafa2.
+            find build -name 'cmake_install.cmake' -exec sed -i 's| -u -r | |g' {} +
+
             cmake --install build --strip --prefix "${INSTALLPATH}" ${V:+--verbose}
             ;;
         *)


### PR DESCRIPTION
The [current](https://github.com/bitcoin/bitcoin/pull/30609) Guix's `cmake-minimal` package has version 3.24.2, which has a [bug](https://gitlab.kitware.com/cmake/cmake/-/issues/24601) that causes wrong options for `llvm-strip`.

This PR has exactly the same effect as the [fixed](https://gitlab.kitware.com/cmake/cmake/-/commit/689616785f76acd844fd448c51c5b2a0711aafa2) CMake versions >= 3.27.

Addresses https://github.com/bitcoin/bitcoin/pull/30454#issuecomment-2277722262:
> Had a look at a Guix build. Stripping the macOS binaries is broken:
> 
> ```shell
> -- Installing: /distsrc-base/distsrc-ad2140d4d8cc-arm64-apple-darwin/installed/bitcoin-ad2140d4d8cc/bin/bitcoind
> /root/.guix-profile/bin/llvm-strip: error: unknown argument '-u'
> ```
