### PR TITLE
cmake: Improve summary output about ccache

### DIFF
--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -11,8 +11,11 @@ if(NOT MSVC)
       ERROR_QUIET
       OUTPUT_STRIP_TRAILING_WHITESPACE
     )
-    if(CCACHE_EXECUTABLE STREQUAL compiler_resolved_link)
-      set(WITH_CCACHE "ccache masquerades as the compiler")
+    if(CCACHE_EXECUTABLE STREQUAL compiler_resolved_link AND NOT WITH_CCACHE)
+      list(APPEND configure_warnings
+        "Disabling ccache was attempted using -DWITH_CCACHE=${WITH_CCACHE}, but ccache masquerades as the compiler."
+      )
+      set(WITH_CCACHE ON)
     elseif(WITH_CCACHE)
       list(APPEND CMAKE_C_COMPILER_LAUNCHER ${CCACHE_EXECUTABLE})
       list(APPEND CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_EXECUTABLE})

--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -20,14 +20,16 @@ if(NOT MSVC)
       list(APPEND CMAKE_C_COMPILER_LAUNCHER ${CCACHE_EXECUTABLE})
       list(APPEND CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_EXECUTABLE})
     endif()
+  else()
+    set(WITH_CCACHE OFF)
+  endif()
+  if(WITH_CCACHE)
     try_append_cxx_flags("-fdebug-prefix-map=A=B" TARGET core_interface SKIP_LINK
       IF_CHECK_PASSED "-fdebug-prefix-map=${PROJECT_SOURCE_DIR}=."
     )
     try_append_cxx_flags("-fmacro-prefix-map=A=B" TARGET core_interface SKIP_LINK
       IF_CHECK_PASSED "-fmacro-prefix-map=${PROJECT_SOURCE_DIR}=."
     )
-  else()
-    set(WITH_CCACHE OFF)
   endif()
 endif()
 


### PR DESCRIPTION
1. From https://github.com/bitcoin/bitcoin/pull/30454#issuecomment-2277886777:
> I think we can improve the output when `-DWITH_CCACHE=OFF` is used. Depending on the system, that output might be:
> 
> ```
> cmake -B build -DWITH_CCACHE=OFF
> < snip >
> Use ccache for compiling .............. ccache masquerades as the compiler
> ```
> 
> We should probably at least indicate that the option was respected by the build-system.

With this PR on Fedora 40:
```
$ cmake -B build -DWITH_CCACHE=OFF
< snip >
Use ccache for compiling .............. ON


  ******

CMake Warning at CMakeLists.txt:656 (message):
  Disabling ccache was attempted using -DWITH_CCACHE=OFF, but ccache
  masquerades as the compiler.


  ******
```

2. The second commit fixes a bug introduced in https://github.com/hebasto/bitcoin/pull/298.