### PR TITLE
cmake: Force build-time dependencies for `deploy` target for macOS

### DIFF
--- a/cmake/module/Maintenance.cmake
+++ b/cmake/module/Maintenance.cmake
@@ -146,7 +146,8 @@ function(add_macos_deploy_target)
       add_custom_target(deploy
         DEPENDS ${PROJECT_BINARY_DIR}/dist/${osx_volname}.zip
       )
-      add_dependencies(deploy deploydir)
     endif()
+    add_dependencies(deploydir bitcoin-qt)
+    add_dependencies(deploy deploydir)
   endif()
 endfunction()

--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -53,5 +53,4 @@ endif()
 
 install(TARGETS test_bitcoin-qt
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  COMPONENT GUI
 )


### PR DESCRIPTION
This PR addresses https://github.com/bitcoin/bitcoin/pull/30454#issuecomment-2288437679:
> Is CMake meant to know about/be able to figure build-time dependencies?

How to test:
- when cross-compiling:
```
$ make -C depends HOST=arm64-apple-darwin
$ cmake -B build --toolchain depends/arm64-apple-darwin/toolchain.cmake
$ cmake --build build -t deploy
```
- on macOS:
```
% cmake -B build -DBUILD_GUI=ON
% cmake --build build -t deploy
```