### PR TITLE
Adjust .gitignore for moved file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,6 @@ config.status
 configure
 libtool
 src/config/bitcoin-config.h
-src/config/bitcoin-config.h.in
 src/config/stamp-h1
 src/obj
 share/setup.nsi


### PR DESCRIPTION
Split out of https://github.com/bitcoin/bitcoin/pull/30454

Removed `bitcoin-config.h.in` from  `.gitignore` since it's not generated anymore